### PR TITLE
Feature: pcr free alignment

### DIFF
--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -70,7 +70,7 @@
     set -eu
     set -o pipefail
 
-    module load {{ constants.tools.bwa.module }}
+    module load {{ constants.tools.bwa_mem2.module }}
     module load {{ constants.tools.samtools.module }}
 
     {#

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -278,13 +278,22 @@
       {% for rgid in sample.read_groups %}
       "{{ temp_dir }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt"
       {%- endfor %}
-      | tail -n +2 | sed 's/\t[a-zA-Z :_]\+/+/g' | awk '{ print $NF }' | bc \
-      > {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt
+      | head -n -1 | tail -n +2 | sed 's/\t[a-zA-Z :_]\+/+/g' | awk '{ print $NF }' | bc \
+      > {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_merge.txt
+
+    paste \
+      {% for rgid in sample.read_groups %}
+      "{{ temp_dir }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt"
+      {%- endfor %}
+      | tail -n1 | sed 's/\t[a-zA-Z :_]\+/\ /g' | cut -d' ' -f2- |\
+      awk '{m=$1;for(i=1;i<=NF;i++)if($i>m)m=$i;print m}' \
+      >> {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_merge.txt
+
 
     {# Combining the summed values with their naming #}
     tail -n +2 {{ temp_dir }}/stats/{{ sample.name }}_{{ first_sample_rgid }}.bwa.bam.samtools.markdup.txt |\
       cut -d':' -f1 |\
-      paste - {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt |\
+      paste - {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_merge.txt |\
       sed 's/\t/: /g' \
       > {{ results_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
 

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -13,6 +13,10 @@
 # This macro splits large fastqs into chunks prior to aligning.
 # If fastq is less than reads_per_chunk (48000000) then one chunk is made.
 {% macro bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) %}
+
+{% set temp_dir %}temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}{% endset %}
+{% set results_dir %}{{ sample.gltype }}/alignment/bwa/{{ sample.name }}{% endset %}
+
 {% for rgid, rg in sample.read_groups.items() %}
 {% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
 {% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
@@ -34,8 +38,8 @@
     set -eu
     set -o pipefail
 
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/"
+    rm -r "{{ temp_dir }}/{{ rgid }}/{{ fastq.basename }}/" || true
+    mkdir -p "{{ temp_dir }}/{{ rgid }}/{{ fastq.basename }}/"
 
     zcat "temp/fastqs/{{ fastq.basename }}" |\
       split \
@@ -43,9 +47,9 @@
         --suffix-length 2 \
         --lines {{ n_lines }} \
         - \
-        "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/"
+        "{{ temp_dir }}/{{ rgid }}/{{ fastq.basename }}/"
 
-    N_CREATED=$(ls "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/" | wc -l)
+    N_CREATED=$(ls "{{ temp_dir }}/{{ rgid }}/{{ fastq.basename }}/" | wc -l)
 
     if [[ ${N_CREATED} -ne {{ n_chunks }} ]]
     then
@@ -63,7 +67,7 @@
   after:
     - split_fastq_{{ r1fastq.basename | replace(".", "_") }}
     - split_fastq_{{ r2fastq.basename | replace(".", "_") }}
-  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
+  output: {{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
   walltime: "48:00:00"
   cpus: 10
   mem: 32G
@@ -79,8 +83,8 @@
     # that will cause errors with samtools sort. Here, we purge any
     # existing temp files before making the directory again.
     #}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/"
+    rm -r "{{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/" || true
+    mkdir -p "{{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/"
 
     {# No long options available for the following:
      bwa mem
@@ -109,20 +113,20 @@
       -t 9 \
       -R "{{ read_group_line(rg, format='bwa') }}" \
       "{{ constants.phoenix.bwa_mem2_index }}" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ r1fastq.basename }}/{{ chunk_suffix }}" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ r2fastq.basename }}/{{ chunk_suffix }}" |\
+      "{{ temp_dir }}/{{ rgid }}/{{ r1fastq.basename }}/{{ chunk_suffix }}" \
+      "{{ temp_dir }}/{{ rgid }}/{{ r2fastq.basename }}/{{ chunk_suffix }}" |\
     samtools fixmate \
       --threads 1 \
       -m \
       - \
       - |\
     samtools sort \
-      -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/{{ chunk_suffix }}" \
+      -T "{{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/{{ chunk_suffix }}" \
       -l 2 \
       -m 768M \
       --threads 9 \
       --output-fmt BAM \
-      -o "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
+      -o "{{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
       -
 
 {% endfor %}
@@ -133,9 +137,9 @@
   input:
     {% for i in range(n_chunks) %}
     {% set chunk_suffix = '%02d' % i %}
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
+    - {{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
     {% endfor %}
-  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam
+  output: {{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.bam
   walltime: "24:00:00"
   cpus: 8
   mem: 8G
@@ -155,13 +159,13 @@
       -c \
       -f \
       -l 6 \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
+      "{{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
       {% for i in range(n_chunks) %}
       {% set chunk_suffix = '%02d' % i %}
       {% if not loop.last %}
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
+      "{{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
       {% else %}
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam"
+      "{{ temp_dir }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam"
       {% endif %}
       {% endfor %}
 
@@ -169,7 +173,7 @@
     # removes fastq chunks and intermediate chunk bam files
     #}
     {% if not debug %}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/"
+    rm -r "{{ temp_dir }}/{{ rgid }}/"
     {% endif %}
 
 
@@ -178,10 +182,10 @@
   reset: predecessors
   methods: Duplicate reads for {{ sample.name }} were marked with
     {{ constants.tools.samtools.verbose }} markdup.
-  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam
+  input: {{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.bam
   output:
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
+    - {{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
+    - {{ temp_dir }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
   walltime: "48:00:00"
   cpus: 4
   mem: 16G
@@ -196,9 +200,10 @@
     # that will cause errors with samtools markdup. Here, we purge any
     # existing temp files before making the directory again.
     #}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}"
-    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
+    rm -r "{{ temp_dir }}/markdup_temp/{{ sample.name }}_{{ rgid }}" || true
+    rm -r "{{ temp_dir }}/stats/" || true
+    mkdir -p "{{ temp_dir }}/markdup_temp/{{ sample.name }}_{{ rgid }}"
+    mkdir -p "{{ temp_dir }}/stats/"
 
     {# No long options available for the following:
      -d      Optical distance
@@ -210,12 +215,12 @@
     samtools markdup \
       -d {{ opt_dup_distance }} \
       -S \
-      -f "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt" \
+      -f "{{ temp_dir }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt" \
       --threads 4 \
       --write-index \
-      -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
+      -T "{{ temp_dir }}/markdup_temp/{{ sample.name }}_{{ rgid }}" \
+      "{{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
+      "{{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
 
 {% endfor %}
 
@@ -226,12 +231,12 @@
     {{ constants.tools.samtools.verbose }} markdup.
   input:
     {% for rgid in sample.read_groups %}
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
+    - {{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
+    - {{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
     {% endfor %}
   output:
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
-    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
+    - {{ temp_dir }}/{{ sample.name }}.bwa.md.bam
+    - {{ results_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
   walltime: "48:00:00"
   cpus: 8
   mem: 16G
@@ -240,6 +245,8 @@
     set -o pipefail
 
     module load {{ constants.tools.samtools.module }}
+
+    mkdir -p "{{ results_dir }}/stats/"
 
     {# No long options available for the following:
       -c           Combine @RG headers with colliding IDs [alter IDs to be distinct]
@@ -251,29 +258,38 @@
       -c \
       -f \
       -l 6 \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam" \
+      "{{ temp_dir }}/{{ sample.name }}.bwa.md.bam" \
     {% for rgid in sample.read_groups %}
       {% if not loop.last %}
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam" \
+      "{{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam" \
       {% else %}
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
+      "{{ temp_dir }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
       {% endif %}
     {% endfor %}
 
     {# Merging markdup stat files #}
-    {% set merge_rgid_sample = (sample.read_groups.values()|first).rgid|default('') %}
+    {% set first_sample_rgid = (sample.read_groups.values()|first).rgid|default('') %}
+
+    {#
+    Pasting the files together and stripping string down to integer values
+    then bc sum them together respectively.
+    #}
     paste \
       {% for rgid in sample.read_groups %}
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools_markdup"
+      "{{ temp_dir }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt"
       {%- endfor %}
       | tail -n +2 | sed 's/\t[a-zA-Z :_]\+/+/g' | awk '{ print $NF }' | bc \
-      > temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt
+      > {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt
 
-    tail -n +2 {{ sample.name }}_{{ merge_rgid_sample }}.bwa.bam.samtools.markdup.txt | cut -d':' -f1 \
-      | paste - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt | sed 's/\t/: /g' \
-      > {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
+    {# Combining the summed values with their naming #}
+    tail -n +2 {{ temp_dir }}/stats/{{ sample.name }}_{{ first_sample_rgid }}.bwa.bam.samtools.markdup.txt |\
+      cut -d':' -f1 |\
+      paste - {{ temp_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt |\
+      sed 's/\t/: /g' \
+      > {{ results_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
 
-    header=$(head -n 1 {{ sample.name }}_{{ merge_rgid_sample }}.bwa.bam.samtools.markdup.txt)
-    sed -i "1s/^/${header}/" {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
+    {# insert COMMAND: into the top of the merged file #}
+    header=$(head -n 1 {{ temp_dir }}/stats/{{ sample.name }}_{{ first_sample_rgid }}.bwa.bam.samtools.markdup.txt)
+    sed -i "1i ${header}" {{ results_dir }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
 
 {% endmacro %}

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -135,7 +135,7 @@
     {% set chunk_suffix = '%02d' % i %}
     - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
     {% endfor %}
-  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam
   walltime: "24:00:00"
   cpus: 8
   mem: 8G
@@ -156,7 +156,13 @@
       -f \
       -l 6 \
       "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/"*.bwa.bam
+      {% for i in range(n_chunks) %}
+      {% set chunk_suffix = '%02d' % i %}
+      {% if not loop.last %}
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
+      {% else %}
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam"
+      {% endfor %}
 
     {# Cleanup the tempfiles
     # removes fastq chunks and intermediate chunk bam files
@@ -171,10 +177,10 @@
   reset: predecessors
   methods: Duplicate reads for {{ sample.name }} were marked with
     {{ constants.tools.samtools.verbose }} markdup.
-  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam
   output:
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
-    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
+    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
   walltime: "48:00:00"
   cpus: 4
   mem: 16G
@@ -217,12 +223,14 @@
   reset: predecessors
   methods: Duplicate reads for {{ sample.name }} were marked with
     {{ constants.tools.samtools.verbose }} markdup.
-  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  input:
+    {% for rgid in sample.read_groups %}
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
+    {% endfor %}
   output:
     - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
-    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt
   walltime: "48:00:00"
-  cpus: 4
+  cpus: 8
   mem: 16G
   cmd: |
     set -eu

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -38,6 +38,14 @@
     set -eu
     set -o pipefail
 
+    {% if fastq.fileType == "fasterq" %}
+      export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+      module load {{ constants.tools.petagene.module }}
+
+    {% endif %}
+    {#
+      This comment is here for protect render spacing, do not remove.
+    #}
     rm -r "{{ temp_dir }}/{{ rgid }}/{{ fastq.basename }}/" || true
     mkdir -p "{{ temp_dir }}/{{ rgid }}/{{ fastq.basename }}/"
 

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -201,7 +201,7 @@
     # existing temp files before making the directory again.
     #}
     rm -r "{{ temp_dir }}/markdup_temp/{{ sample.name }}_{{ rgid }}" || true
-    rm -r "{{ temp_dir }}/stats/" || true
+    rm "{{ temp_dir }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt" || true
     mkdir -p "{{ temp_dir }}/markdup_temp/{{ sample.name }}_{{ rgid }}"
     mkdir -p "{{ temp_dir }}/stats/"
 

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -63,6 +63,7 @@
   after:
     - split_fastq_{{ r1fastq.basename | replace(".", "_") }}
     - split_fastq_{{ r2fastq.basename | replace(".", "_") }}
+  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
   walltime: "48:00:00"
   cpus: 10
   mem: 50G
@@ -129,7 +130,11 @@
 - name: chunked_samtools_merge_rgid_bams_{{ sample.name }}_{{ rgid }}
   tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, {{ sample.name }}]
   reset: predecessors
-  after-re: chunked_bwa_mem_samtools_fixmate_{{ sample.name }}_.*
+  input:
+    {% for i in range(n_chunks) %}
+    {% set chunk_suffix = '%02d' % i %}
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
+    {% endfor %}
   output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
   walltime: "24:00:00"
   cpus: 8

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -162,6 +162,7 @@
       "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
       {% else %}
       "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam"
+      {% endif %}
       {% endfor %}
 
     {# Cleanup the tempfiles

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -1,0 +1,247 @@
+# Aligns fastqs for a sample using BWA MEM2. Samples may have multiple read
+# groups.
+#
+#     ? ?
+#   ? -----fastqs--> temp/<sample.name>.bwa.bam
+#     ? ?
+#
+
+# This alignment command prefix is shared by all modules using bwa
+{% from 'utilities/read_group_line.jst' import read_group_line with context %}
+{% from 'utilities/remove_files.jst' import remove_files with context %}
+
+# This macro splits large fastqs into chunks prior to aligning.
+# If fastq is less than reads_per_chunk (48000000) then one chunk is made.
+{% macro bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) %}
+{% for rgid, rg in sample.read_groups.items() %}
+{% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
+{% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
+
+{# Comment about the math, using the assumed legacy illumina interpretation, it is a TGen modification #}
+{% set n_lines = (reads_per_chunk * 4)|int %}
+{% set n_chunks = (r1fastq.numberOfReads / 2 / reads_per_chunk)|round(0, method='ceil')|int %}
+{% if n_chunks > 99 %}{{ raise('ValueError', 'Too many chunks!') }}{% endif %}
+
+{% for fastq in [r1fastq, r2fastq] %}
+- name: split_fastq_{{ fastq.basename | replace(".", "_") }}
+  tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, split, {{ sample.name }}]
+  reset: predecessors
+  input:
+    - temp/fastqs/{{ fastq.basename }}
+  cpus: 1
+  walltime: "4:00:00"
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/"
+
+    zcat "temp/fastqs/{{ fastq.basename }}" |\
+      split \
+        --numeric-suffixes \
+        --suffix-length 2 \
+        --lines {{ n_lines }} \
+        - \
+        "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/"
+
+    N_CREATED=$(ls "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ fastq.basename }}/" | wc -l)
+
+    if [[ ${N_CREATED} -ne {{ n_chunks }} ]]
+    then
+      echo "Chunks created does not match expected value"
+      exit 1
+    fi
+
+{% endfor %}
+
+{% for i in range(n_chunks) %}
+{% set chunk_suffix = '%02d' % i %}
+- name: chunked_bwa_mem2_samtools_fixmate_{{ sample.name }}_{{ rgid }}_{{ chunk_suffix }}
+  tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, {{ sample.name }}]
+  reset: predecessors
+  after:
+    - split_fastq_{{ r1fastq.basename | replace(".", "_") }}
+    - split_fastq_{{ r2fastq.basename | replace(".", "_") }}
+  walltime: "48:00:00"
+  cpus: 10
+  mem: 50G
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.bwa.module }}
+    module load {{ constants.tools.samtools.module }}
+
+    {#
+    # If this task was interrupted previously, temp files may exist
+    # that will cause errors with samtools sort. Here, we purge any
+    # existing temp files before making the directory again.
+    #}
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/"
+
+    {# No long options available for the following:
+     bwa mem
+        -v INT       Verbosity: 3 = message (default = 3)
+        -Y           Use soft clipping for supplementary alignments
+        -K INT       Process INT input bases in each batch regardless of nThreads (for reproducibility)
+        -t INT       Number of threads to use
+        -R STR       Read group header line such as '@RG\tID:foo\tSM:bar' [null]
+
+     samtools fixmate
+        -m           Add mate score tag, REQUIRED for samtools markdup
+        -            Input from stdin
+        -            Output to stdout
+
+     samtools sort
+        -l INT       Set compression level, from 0 (uncompressed) to 9 (best)
+        -m INT       Set maximum memory per thread; suffix K/M/G recognized [768M]
+        -T PREFIX    Write temporary files to PREFIX.nnnn.bam
+        -            Input from stdin
+        -o FILE      Write final output to FILE rather than standard output
+    #}
+    bwa-mem2 mem \
+      -v 3 \
+      -Y \
+      -K 100000000 \
+      -t 9 \
+      -R "{{ read_group_line(rg, format='bwa') }}" \
+      "{{ constants.phoenix.bwa_mem2_index }}" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ r1fastq.basename }}/{{ chunk_suffix }}" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ r2fastq.basename }}/{{ chunk_suffix }}" |\
+    samtools fixmate \
+      --threads 1 \
+      -m \
+      - \
+      - |\
+    samtools sort \
+      -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/{{ chunk_suffix }}" \
+      -l 2 \
+      -m 3G \
+      --threads 9 \
+      --output-fmt BAM \
+      -o "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \
+      -
+
+{% endfor %}
+
+- name: chunked_samtools_merge_rgid_bams_{{ sample.name }}_{{ rgid }}
+  tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, {{ sample.name }}]
+  reset: predecessors
+  after-re: chunked_bwa_mem_samtools_fixmate_{{ sample.name }}_.*
+  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  walltime: "24:00:00"
+  cpus: 8
+  mem: 8G
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.samtools.module }}
+
+    {# No long options available for the following:
+      -c           Combine @RG headers with colliding IDs [alter IDs to be distinct]
+      -f           Overwrite the output BAM if exist
+      -l INT       Compression level, from 0 to 9 [-1]
+    #}
+    samtools merge \
+      --threads 8 \
+      -c \
+      -f \
+      -l 6 \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/"*.bwa.bam
+
+    {# Cleanup the tempfiles
+    # removes fastq chunks and intermediate chunk bam files
+    #}
+    {% if not debug %}
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/"
+    {% endif %}
+
+
+- name: samtools_markdup_{{ sample.name }}_{{ rgid }}_bwa
+  tags: [{{ sample.gltype }}, alignment, mark_duplicates, samtools, {{ sample.name }}]
+  reset: predecessors
+  methods: Duplicate reads for {{ sample.name }} were marked with
+    {{ constants.tools.samtools.verbose }} markdup.
+  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  output:
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
+    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt
+  walltime: "48:00:00"
+  cpus: 4
+  mem: 16G
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.samtools.module }}
+
+    {#
+    # If this task was interrupted previously, temp files may exist
+    # that will cause errors with samtools markdup. Here, we purge any
+    # existing temp files before making the directory again.
+    #}
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/"
+    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
+
+    {# No long options available for the following:
+     -d      Optical distance
+     -S      Mark supplemenary alignments of duplicates as duplicates (slower)
+     -f      Write stats to named file. Implies -s (report stats)
+     -T      PREFIX    Write temporary files to PREFIX.samtools.nnnn.nnnn.tmp
+     2>      Stats are output to stderr which is redirected to ".bwa.bam.markdup.txt"
+    #}
+    samtools markdup \
+      -d {{ opt_dup_distance }} \
+      -S \
+      -f "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt" \
+      --threads 4 \
+      --write-index \
+      -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
+
+{% endfor %}
+
+- name: samtools_markdup_merge_rg_bams_{{ sample.name }}
+  tags: [{{ sample.gltype }}, alignment, mark_duplicates, samtools, {{ sample.name }}]
+  reset: predecessors
+  methods: Duplicate reads for {{ sample.name }} were marked with
+    {{ constants.tools.samtools.verbose }} markdup.
+  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  output:
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
+    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt
+  walltime: "48:00:00"
+  cpus: 4
+  mem: 16G
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.samtools.module }}
+
+    {# No long options available for the following:
+      -c           Combine @RG headers with colliding IDs [alter IDs to be distinct]
+      -f           Overwrite the output BAM if exist
+      -l INT       Compression level, from 0 to 9 [-1]
+    #}
+    samtools merge \
+      --threads 8 \
+      -c \
+      -f \
+      -l 6 \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam" \
+    {% for rgid in sample.read_groups %}
+      {% if not loop.last %}
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam" \
+      {% else %}
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
+      {% endif %}
+    {% endfor %}
+
+{% endmacro %}

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -66,7 +66,7 @@
   output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam
   walltime: "48:00:00"
   cpus: 10
-  mem: 50G
+  mem: 32G
   cmd: |
     set -eu
     set -o pipefail
@@ -119,7 +119,7 @@
     samtools sort \
       -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}_st_sort_temp/{{ chunk_suffix }}" \
       -l 2 \
-      -m 3G \
+      -m 768M \
       --threads 9 \
       --output-fmt BAM \
       -o "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}/{{ chunk_suffix }}.bwa.bam" \

--- a/modules/dna_alignment/bwa_mem2_samtools.jst
+++ b/modules/dna_alignment/bwa_mem2_samtools.jst
@@ -181,7 +181,7 @@
   input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam
   output:
     - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
-    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
   walltime: "48:00:00"
   cpus: 4
   mem: 16G
@@ -196,8 +196,8 @@
     # that will cause errors with samtools markdup. Here, we purge any
     # existing temp files before making the directory again.
     #}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/"
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}"
     mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
 
     {# No long options available for the following:
@@ -210,7 +210,7 @@
     samtools markdup \
       -d {{ opt_dup_distance }} \
       -S \
-      -f "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt" \
+      -f "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt" \
       --threads 4 \
       --write-index \
       -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}_{{ rgid }}" \
@@ -227,9 +227,11 @@
   input:
     {% for rgid in sample.read_groups %}
     - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools.markdup.txt
     {% endfor %}
   output:
     - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
+    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
   walltime: "48:00:00"
   cpus: 8
   mem: 16G
@@ -257,5 +259,21 @@
       "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.md.bam"
       {% endif %}
     {% endfor %}
+
+    {# Merging markdup stat files #}
+    {% set merge_rgid_sample = (sample.read_groups.values()|first).rgid|default('') %}
+    paste \
+      {% for rgid in sample.read_groups %}
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}_{{ rgid }}.bwa.bam.samtools_markdup"
+      {%- endfor %}
+      | tail -n +2 | sed 's/\t[a-zA-Z :_]\+/+/g' | awk '{ print $NF }' | bc \
+      > temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt
+
+    tail -n +2 {{ sample.name }}_{{ merge_rgid_sample }}.bwa.bam.samtools.markdup.txt | cut -d':' -f1 \
+      | paste - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup_sum.txt | sed 's/\t/: /g' \
+      > {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
+
+    header=$(head -n 1 {{ sample.name }}_{{ merge_rgid_sample }}.bwa.bam.samtools.markdup.txt)
+    sed -i "1s/^/${header}/" {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools_markdup.txt
 
 {% endmacro %}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -44,7 +44,7 @@
 
     {% if sample.glprep == "pcrfree" %}
       {{- bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
-    {% if sample.glprep == "parabricks" %}
+    {% elif sample.glprep == "parabricks" %}
       {{- fq2bam(sample, opt_dup_distance) }}
     {% else %}
       {% if alignment_style == 'tgen' %}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -2,6 +2,7 @@
 # Take DNA fastq data files to aligned bams with qc data
 {% from 'modules/dna_alignment/bwa_mem_samtools.jst' import bwa_mem_samtools_chunked with context %}
 {% from 'modules/dna_alignment/bwa_mem2_samtools.jst' import bwa_mem2_samtools_chunked with context %}
+{% from 'modules/dna_alignment/pb_fq2bam.jst' import fq2bam with context %}
 {% from 'modules/dna_alignment/bwa_mem_gatk_picard.jst' import bwa_mem_gatk_picard_chunked with context %}
 {% from 'modules/dna_alignment/bwa_mem_samblaster_sambamba.jst' import bwa_mem_blaster_bamba with context %}
 {% from 'modules/dna_alignment/bowtie2_samtools.jst' import bowtie2_samtools_chunked with context %}
@@ -43,6 +44,8 @@
 
     {% if sample.glprep == "pcrfree" %}
       {{- bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
+    {% if sample.glprep == "parabricks" %}
+      {{- fq2bam(sample, opt_dup_distance) }}
     {% else %}
       {% if alignment_style == 'tgen' %}
         {{- bwa_mem_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -1,6 +1,7 @@
 # DNA Alignment with BWA MEM
 # Take DNA fastq data files to aligned bams with qc data
 {% from 'modules/dna_alignment/bwa_mem_samtools.jst' import bwa_mem_samtools_chunked with context %}
+{% from 'modules/dna_alignment/bwa_mem2_samtools.jst' import bwa_mem2_samtools_chunked with context %}
 {% from 'modules/dna_alignment/bwa_mem_gatk_picard.jst' import bwa_mem_gatk_picard_chunked with context %}
 {% from 'modules/dna_alignment/bwa_mem_samblaster_sambamba.jst' import bwa_mem_blaster_bamba with context %}
 {% from 'modules/dna_alignment/bowtie2_samtools.jst' import bowtie2_samtools_chunked with context %}
@@ -40,14 +41,18 @@
       {% set opt_dup_distance = 100 %}
     {% endif %}
 
-    {% if alignment_style == 'tgen' %}
-      {{- bwa_mem_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
-    {% elif alignment_style == 'broad'  %}
-      {{- bwa_mem_gatk_picard_chunked(sample, reads_per_chunk, opt_dup_distance) }}
-    {% elif alignment_style == 'ashion' %}
-      {{- bwa_mem_blaster_bamba(sample) }}
+    {% if sample.glprep == "pcrfree" %}
+      {{- bwa_mem2_samtools_chunked }}
     {% else %}
-      {{ raise('Unknown dnaAlignmentStyle: {}'.format(dnaAlignmentStyle)) }}
+      {% if alignment_style == 'tgen' %}
+        {{- bwa_mem_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
+      {% elif alignment_style == 'broad'  %}
+        {{- bwa_mem_gatk_picard_chunked(sample, reads_per_chunk, opt_dup_distance) }}
+      {% elif alignment_style == 'ashion' %}
+        {{- bwa_mem_blaster_bamba(sample) }}
+      {% else %}
+        {{ raise('Unknown dnaAlignmentStyle: {}'.format(dnaAlignmentStyle)) }}
+      {% endif %}
     {% endif %}
 
     {% if sample.gltype == 'genome' %}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -42,10 +42,9 @@
       {% set opt_dup_distance = 100 %}
     {% endif %}
 
-    {% if sample.glprep == "pcrfree" %}
+    {# PCRfree will not have any pcr cycles #}
+    {% if sample.number_of_cycles is defined and sample.number_of_cycles == 0 %}
       {{- bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
-    {% elif sample.glprep == "parabricks" %}
-      {{- fq2bam(sample, opt_dup_distance) }}
     {% else %}
       {% if alignment_style == 'tgen' %}
         {{- bwa_mem_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -43,7 +43,7 @@
     {% endif %}
 
     {# PCRfree will not have any pcr cycles #}
-    {% if sample.number_of_cycles is defined and sample.number_of_cycles == 0 %}
+    {% if sample.numberOfAmpCycles is defined and sample.numberOfAmpCycles == 0 %}
       {{- bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
     {% else %}
       {% if alignment_style == 'tgen' %}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -42,7 +42,7 @@
     {% endif %}
 
     {% if sample.glprep == "pcrfree" %}
-      {{- bwa_mem2_samtools_chunked }}
+      {{- bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
     {% else %}
       {% if alignment_style == 'tgen' %}
         {{- bwa_mem_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}

--- a/modules/dna_alignment/main.jst
+++ b/modules/dna_alignment/main.jst
@@ -43,7 +43,7 @@
     {% endif %}
 
     {# PCRfree will not have any pcr cycles #}
-    {% if sample.numberOfAmpCycles is defined and sample.numberOfAmpCycles == 0 %}
+    {% if sample.pcrCycles is defined and sample.pcrCycles == 0 %}
       {{- bwa_mem2_samtools_chunked(sample, reads_per_chunk, opt_dup_distance) }}
     {% else %}
       {% if alignment_style == 'tgen' %}

--- a/modules/dna_alignment/pb_fq2bam.jst
+++ b/modules/dna_alignment/pb_fq2bam.jst
@@ -1,0 +1,47 @@
+# Aligns fastqs from a sample using Parabricks fq2BAM. This aligns all samples
+# in on large run. No need to split or merge. It will also run
+# mark duplicatese and BQSR if needed
+
+# This alignment command prefix is shared by all modules using bwa
+{% from 'utilities/read_group_line.jst' import read_group_line with context %}
+{% from 'utilities/remove_files.jst' import remove_files with context %}
+
+{% macro fq2bam(sample) %}
+  {% set bam %}{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam{% endset %}
+
+- name: fq2bam_{{sample.name}}
+  tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, {{ sample.name }}]
+  reset: predecessors
+  input:
+  {% for rgid, rg in sample.read_groups.items() %}
+    {% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
+    {% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
+    - temp/fastqs/{{ r1fastq.basename }}
+    - temp/fastqs/{{ r2fastq.basename }}
+  {% endfor %}
+  output: {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  walltime: "24:00:00"
+  sbatch_args: ['-p', 'gpu', '--exclusive']
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}"
+    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}"
+    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
+
+    module load {{ constants.tools.parabricks.module }}
+
+    pbrun fq2bam \
+    --ref "{{ constants.phoenix.reference_fasta }}" \
+    --bwa-options "-Y -K 100000000" \
+    {% for rgid, rg in sample.read_groups.items() %}
+      {% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
+      {% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
+      --in-fq "temp/fastqs/{{ r1fastq.basename }}" "temp/fastqs/{{ r2fastq.basename }}" "{{ read_group_line(rg, format='bwa') }}" \
+    {% endfor %}
+    --output-duplicate-metrics {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt \
+    --out-bam "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam"
+
+{% endmacro %}

--- a/modules/dna_alignment/pb_fq2bam.jst
+++ b/modules/dna_alignment/pb_fq2bam.jst
@@ -26,13 +26,15 @@
     set -eu
     set -o pipefail
 
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}"
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/"
     mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}"
+    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
 
     module load {{ constants.tools.parabricks.module }}
 
     pbrun fq2bam \
+    --tmp-dir "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/" \
     --ref "{{ constants.phoenix.bwa_index }}" \
     --bwa-options "-Y -K 100000000" \
     {% for rgid, rg in sample.read_groups.items() %}
@@ -40,55 +42,8 @@
       {% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
       --in-fq "temp/fastqs/{{ r1fastq.basename }}" "temp/fastqs/{{ r2fastq.basename }}" "{{ read_group_line(rg, format='bwa') }}" \
     {% endfor %}
-    --out-bam "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam"
-
-- name: samtools_markdup_{{ sample.name }}_bwa
-  tags: [{{ sample.gltype }}, alignment, mark_duplicates, samtools, {{ sample.name }}]
-  reset: predecessors
-  methods: Duplicate reads for {{ sample.name }} were marked with
-    {{ constants.tools.samtools.verbose }} markdup.
-  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
-  output:
-    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
-    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt
-  walltime: "48:00:00"
-  cpus: 4
-  mem: 16G
-  cmd: |
-    set -eu
-    set -o pipefail
-
-    module load {{ constants.tools.samtools.module }}
-
-    {#
-    # If this task was interrupted previously, temp files may exist
-    # that will cause errors with samtools markdup. Here, we purge any
-    # existing temp files before making the directory again.
-    #}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/"
-    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
-
-    {#
-    # Choose an optical distance based on sequencer
-    #}
-
-    {# No long options available for the following:
-     -d      Optical distance
-     -S      Mark supplemenary alignments of duplicates as duplicates (slower)
-     -f      Write stats to named file. Implies -s (report stats)
-     -T      PREFIX    Write temporary files to PREFIX.samtools.nnnn.nnnn.tmp
-     2>      Stats are output to stderr which is redirected to ".bwa.bam.markdup.txt"
-    #}
-    samtools markdup \
-      -d {{ opt_dup_distance }} \
-      -S \
-      -f "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt" \
-      --threads 4 \
-      --write-index \
-      -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam" \
-      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam"
-
+    --out-duplicate-metrics "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.mdmetrics.txt" \
+    --optical-duplicate-pixel-distance {{ opt_dup_distance }} \
+    --out-bam "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam"
 
 {% endmacro %}

--- a/modules/dna_alignment/pb_fq2bam.jst
+++ b/modules/dna_alignment/pb_fq2bam.jst
@@ -6,7 +6,7 @@
 {% from 'utilities/read_group_line.jst' import read_group_line with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
 
-{% macro fq2bam(sample) %}
+{% macro fq2bam(sample, opt_dup_distance) %}
   {% set bam %}{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam{% endset %}
 
 - name: fq2bam_{{sample.name}}
@@ -42,6 +42,7 @@
       --in-fq "temp/fastqs/{{ r1fastq.basename }}" "temp/fastqs/{{ r2fastq.basename }}" "{{ read_group_line(rg, format='bwa') }}" \
     {% endfor %}
     --output-duplicate-metrics {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt \
+    --output-duplicate-pixel-distance {{ opt_dup_distance }} \
     --out-bam "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam"
 
 {% endmacro %}

--- a/modules/dna_alignment/pb_fq2bam.jst
+++ b/modules/dna_alignment/pb_fq2bam.jst
@@ -19,7 +19,7 @@
     - temp/fastqs/{{ r1fastq.basename }}
     - temp/fastqs/{{ r2fastq.basename }}
   {% endfor %}
-  output: {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  output: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
   walltime: "24:00:00"
   sbatch_args: ['-p', 'gpu', '--exclusive']
   cmd: |
@@ -29,20 +29,66 @@
     rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}" || true
     mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}"
     mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}"
-    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
 
     module load {{ constants.tools.parabricks.module }}
 
     pbrun fq2bam \
-    --ref "{{ constants.phoenix.reference_fasta }}" \
+    --ref "{{ constants.phoenix.bwa_index }}" \
     --bwa-options "-Y -K 100000000" \
     {% for rgid, rg in sample.read_groups.items() %}
       {% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
       {% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
       --in-fq "temp/fastqs/{{ r1fastq.basename }}" "temp/fastqs/{{ r2fastq.basename }}" "{{ read_group_line(rg, format='bwa') }}" \
     {% endfor %}
-    --output-duplicate-metrics {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt \
-    --output-duplicate-pixel-distance {{ opt_dup_distance }} \
-    --out-bam "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam"
+    --out-bam "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam"
+
+- name: samtools_markdup_{{ sample.name }}_bwa
+  tags: [{{ sample.gltype }}, alignment, mark_duplicates, samtools, {{ sample.name }}]
+  reset: predecessors
+  methods: Duplicate reads for {{ sample.name }} were marked with
+    {{ constants.tools.samtools.verbose }} markdup.
+  input: temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam
+  output:
+    - temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam
+    - {{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt
+  walltime: "48:00:00"
+  cpus: 4
+  mem: 16G
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.samtools.module }}
+
+    {#
+    # If this task was interrupted previously, temp files may exist
+    # that will cause errors with samtools markdup. Here, we purge any
+    # existing temp files before making the directory again.
+    #}
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/"
+    mkdir -p "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/"
+
+    {#
+    # Choose an optical distance based on sequencer
+    #}
+
+    {# No long options available for the following:
+     -d      Optical distance
+     -S      Mark supplemenary alignments of duplicates as duplicates (slower)
+     -f      Write stats to named file. Implies -s (report stats)
+     -T      PREFIX    Write temporary files to PREFIX.samtools.nnnn.nnnn.tmp
+     2>      Stats are output to stderr which is redirected to ".bwa.bam.markdup.txt"
+    #}
+    samtools markdup \
+      -d {{ opt_dup_distance }} \
+      -S \
+      -f "{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/stats/{{ sample.name }}.bwa.bam.samtools.markdup.txt" \
+      --threads 4 \
+      --write-index \
+      -T "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/markdup_temp/{{ sample.name }}" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.bam" \
+      "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ sample.name }}.bwa.md.bam"
+
 
 {% endmacro %}

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -37,6 +37,10 @@ constants:
       citation: >
         Li H. and Durbin R. (2009) Fast and accurate short read alignment with Burrows-Wheeler Transform.
         Bioinformatics, 25:1754-60. [PMID: 19451168]
+    bwa_mem2:
+      module: bwa-mem2/2.2.1
+      version: "2.2.1"
+      verbose: Burrows-Wheeler Aligner v2.2.1
     cellranger:
       module: cellranger/3.1.0
       version: "3.1.0"
@@ -458,6 +462,7 @@ constants:
       - /home/tgenref/homo_sapiens/grch38_hg38/public_databases/broad_resource_bundle/Homo_sapiens_assembly38.known_indels.vcf.gz
       - /home/tgenref/homo_sapiens/grch38_hg38/public_databases/broad_resource_bundle/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
     bwa_index: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/tool_resources/bwa_0.7.17/GRCh38tgen_decoy_alts_hla.fa
+    bwa_mem2_index: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/tool_resources/bwa2_2.2.1/GRCh38tgen_decoy_alts_hla.fa
     gtf: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/gene_model/ensembl_v98/Homo_sapiens.GRCh38.98.ucsc.gtf
     ref_flat: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/gene_model/ensembl_v98/Homo_sapiens.GRCh38.98.ucsc.refFlat.txt
     ig_ENST_filter: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/gene_model/ensembl_v98/disease_specific_resources/myeloma/Homo_sapiens_GRCh38_98_ucsc_ig_ENST_to_filter_out.tsv


### PR DESCRIPTION
This adds two new workflows designed with pcr free alignment in mind. The primary workflow uses bwa-mem2 and marks duplicates at the lane level before merging into one alignment file. We also have the fq2bam workflow which is gpu-accelerated, but this isn't called in the main.jst as it will likely be bottlenecked on our compute cluster.