### PR TITLE
Cellranger update

### DIFF
--- a/modules/single_cell/cellranger_count.jst
+++ b/modules/single_cell/cellranger_count.jst
@@ -74,7 +74,7 @@
     ( cd {{ temp_dir }} && cellranger count \
       --localcores 20 \
       --localmem 160 \
-      --expect-cells {{ sample.expected_cells | default(3000) }} \
+      --expect-cells {{ sample.expectedCells | default(3000) }} \
       --chemistry "{{ constants.phoenix.scrna_chemistry_options[sample.assayCode].chemistry_name }}" \
       --id "{{ sample.name }}" \
       --fastqs . \

--- a/modules/single_cell/cellranger_count.jst
+++ b/modules/single_cell/cellranger_count.jst
@@ -54,12 +54,19 @@
 
     module load {{ constants.tools.cellranger.module }}
     module load {{ constants.tools.samtools.module }}
+    {% for fq in files %}
+      {% if fq.fileType == "fasterq" and petagene not defined %}
+        export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+        module load {{ constants.tools.petagene.module }}
+        {% set petagene=true %}
+      {% endif %}
+    {% endfor %}
 
     rm -r "{{ temp_dir }}" || true
     mkdir -p "{{ temp_dir }}"
     mkdir -p "{{ outdir }}"
     mkdir -p "{{ alignment_outdir }}/stats"
-    
+
     {% for fq in files %}
     ln -rs "temp/fastqs/{{ fq.basename }}" "{{ temp_dir }}/{{ fq.basename }}"
     {% endfor %}
@@ -71,6 +78,7 @@
     ( cd {{ temp_dir }} && cellranger count \
       --localcores 20 \
       --localmem 160 \
+      --expect-cells {{ sample.expected_cells }} \
       --chemistry "{{ constants.phoenix.scrna_chemistry_options[sample.assayCode].chemistry_name }}" \
       --id "{{ sample.name }}" \
       --fastqs . \

--- a/modules/single_cell/cellranger_count.jst
+++ b/modules/single_cell/cellranger_count.jst
@@ -21,10 +21,6 @@
   {% set directory %}{{ cellranger_out }}/analysis{% endset %}
 
   {% set samples_list = [] %}
-  {% for rgpu, _ in files|groupby('rgpu') %}
-    {% set sample_string %}{{ sample.name }}_{{ rgpu[:-2] }}{% endset %}
-    {% do samples_list.append(sample_string) %}
-  {% endfor %}
 
 - name: cellranger_count_{{ sample.name }}
   tags: [{{ sample.gltype }}, single_cell, cellranger_count, {{ sample.name }}]
@@ -65,7 +61,10 @@
     mkdir -p "{{ alignment_outdir }}/stats"
 
     {% for fq in files %}
-    ln -rs "temp/fastqs/{{ fq.basename }}" "{{ temp_dir }}/{{ fq.basename }}"
+      {% set fq_name %}{{ fq.name }}_{{ fq.rgpu[:-2] }}_{{ fq.rgbc }}{% endset %}
+      {% set fq_new %}{{ fq_name }}_S1{% endset %}
+      {% do samples_list.append(fq_name) %}
+      ln -rs "temp/fastqs/{{ fq.basename }}" "{{ temp_dir }}/{{ fq.basename | replace(fq_name, fq_new) }}"
     {% endfor %}
 
     {#
@@ -75,7 +74,7 @@
     ( cd {{ temp_dir }} && cellranger count \
       --localcores 20 \
       --localmem 160 \
-      --expect-cells {{ sample.expected_cells }} \
+      --expect-cells {{ sample.expected_cells | default(3000) }} \
       --chemistry "{{ constants.phoenix.scrna_chemistry_options[sample.assayCode].chemistry_name }}" \
       --id "{{ sample.name }}" \
       --fastqs . \

--- a/modules/single_cell/cellranger_count.jst
+++ b/modules/single_cell/cellranger_count.jst
@@ -54,13 +54,10 @@
 
     module load {{ constants.tools.cellranger.module }}
     module load {{ constants.tools.samtools.module }}
-    {% for fq in files %}
-      {% if fq.fileType == "fasterq" and petagene not defined %}
-        export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
-        module load {{ constants.tools.petagene.module }}
-        {% set petagene=true %}
-      {% endif %}
-    {% endfor %}
+    {% if sample.fileType == "fasterq" %}
+      export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+      module load {{ constants.tools.petagene.module }}
+    {% endif %}
 
     rm -r "{{ temp_dir }}" || true
     mkdir -p "{{ temp_dir }}"

--- a/modules/single_cell/cellranger_vdj.jst
+++ b/modules/single_cell/cellranger_vdj.jst
@@ -67,6 +67,13 @@
     set -o pipefail
 
     module load {{ constants.tools.cellranger.module }}
+    {% for fq in files %}
+      {% if fq.fileType == "fasterq" and petagene not defined %}
+        export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+        module load {{ constants.tools.petagene.module }}
+        {% set petagene=true %}
+      {% endif %}
+    {% endfor %}
 
     rm -r "{{ temp_dir }}" || true
     mkdir -p "{{ temp_dir }}"

--- a/modules/single_cell/cellranger_vdj.jst
+++ b/modules/single_cell/cellranger_vdj.jst
@@ -43,18 +43,21 @@
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.concat_ref.fasta
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.concat_ref.fasta.fai
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus_annotations.csv
-    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus_annotations.json
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.bam
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.bam.bai
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.fasta
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.fasta.fai
-    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.fastq
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.filtered_contig_annotations.csv
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.filtered_contig.fasta
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.filtered_contig.fastq
     - {{ metrics_output }}
     - {{ outdir }}/{{ sample.name }}.cellranger_vdj.vloupe
     - {{ outdir }}/stats/{{ sample.name }}.cellranger_vdj.bam.web_summary.html
+    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.airr_rearrangement.tsv
+    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.vdj_contig_info.pb
+    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.donor_regions.fa
+    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.regions.fa
+    - {{ outdir }}/{{ sample.name }}.cellranger_vdj.reference.json
   cpus: 20
   mem: 80G
   walltime: "48:00:00"
@@ -106,18 +109,21 @@
     mv {{ cellranger_out }}/concat_ref.fasta {{ outdir }}/{{ sample.name }}.cellranger_vdj.concat_ref.fasta
     mv {{ cellranger_out }}/concat_ref.fasta.fai {{ outdir }}/{{ sample.name }}.cellranger_vdj.concat_ref.fasta.fai
     mv {{ cellranger_out }}/consensus_annotations.csv {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus_annotations.csv
-    mv {{ cellranger_out }}/consensus_annotations.json {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus_annotations.json
     mv {{ cellranger_out }}/consensus.bam {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.bam
     mv {{ cellranger_out }}/consensus.bam.bai {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.bam.bai
     mv {{ cellranger_out }}/consensus.fasta {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.fasta
     mv {{ cellranger_out }}/consensus.fasta.fai {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.fasta.fai
-    mv {{ cellranger_out }}/consensus.fastq {{ outdir }}/{{ sample.name }}.cellranger_vdj.consensus.fastq
     mv {{ cellranger_out }}/filtered_contig_annotations.csv {{ outdir }}/{{ sample.name }}.cellranger_vdj.filtered_contig_annotations.csv
     mv {{ cellranger_out }}/filtered_contig.fasta {{ outdir }}/{{ sample.name }}.cellranger_vdj.filtered_contig.fasta
     mv {{ cellranger_out }}/filtered_contig.fastq {{ outdir }}/{{ sample.name }}.cellranger_vdj.filtered_contig.fastq
     mv {{ cellranger_out }}/metrics_summary.csv {{ metrics_output }}
     mv {{ cellranger_out }}/vloupe.vloupe {{ outdir }}/{{ sample.name }}.cellranger_vdj.vloupe
     mv {{ cellranger_out }}/web_summary.html {{ outdir }}/stats/{{ sample.name }}.cellranger_vdj.bam.web_summary.html
+    mv {{ cellranger_out }}/airr_rearrangement.tsv {{ outdir }}/{{ sample.name }}.cellranger_vdj.airr_rearrangement.tsv
+    mv {{ cellranger_out }}/vdj_contig_info.pb {{ outdir }}/{{ sample.name }}.cellranger_vdj.vdj_contig_info.pb
+    mv {{ cellranger_out }}/vdj_reference/fasta/donor_regions.fa {{ outdir }}/{{ sample.name }}.cellranger_vdj.donor_regions.fa
+    mv {{ cellranger_out }}/vdj_reference/fasta/regions.fa {{ outdir }}/{{ sample.name }}.cellranger_vdj.regions.fa
+    mv {{ cellranger_out }}/vdj_reference/reference.json {{ outdir }}/{{ sample.name }}.cellranger_vdj.reference.json
 
   {{- stats2json(sample.gltype, sample.name, task, metrics_output, json, "cellranger_vdj_metrics", sample_name=sample.name, library_name=sample.rglb) }}
 

--- a/modules/single_cell/cellranger_vdj.jst
+++ b/modules/single_cell/cellranger_vdj.jst
@@ -16,10 +16,6 @@
 {% set json %}{{ outdir }}/stats/{{ sample.name }}.cellranger_vdj.bam.metrics_summary.json{% endset %}
 
 {% set samples_list = [] %}
-{% for rgpu, _ in files|groupby('rgpu') %}
-  {% set sample_string %}{{ sample.name }}_{{ rgpu[:-2] }}{% endset %}
-  {% do samples_list.append(sample_string) %}
-{% endfor %}
 
 - name: cellranger_vdj_{{ sample.name }}
   tags: [{{ sample.gltype }}, single_cell, cellranger_vdj, {{ sample.name }}]
@@ -77,7 +73,10 @@
     mkdir -p "{{ outdir }}/stats"
 
     {% for fq in files %}
-    ln -rs "temp/fastqs/{{ fq.basename }}" "{{ temp_dir }}/{{ fq.basename }}"
+      {% set fq_name %}{{ fq.name }}_{{ fq.rgpu[:-2] }}_{{ fq.rgbc }}{% endset %}
+      {% set fq_new %}{{ fq_name }}_S1{% endset %}
+      {% do samples_list.append(fq_name) %}
+      ln -rs "temp/fastqs/{{ fq.basename }}" "{{ temp_dir }}/{{ fq.basename | replace(fq_name, fq_new) }}"
     {% endfor %}
 
     {#

--- a/modules/single_cell/cellranger_vdj.jst
+++ b/modules/single_cell/cellranger_vdj.jst
@@ -67,13 +67,10 @@
     set -o pipefail
 
     module load {{ constants.tools.cellranger.module }}
-    {% for fq in files %}
-      {% if fq.fileType == "fasterq" and petagene not defined %}
-        export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
-        module load {{ constants.tools.petagene.module }}
-        {% set petagene=true %}
-      {% endif %}
-    {% endfor %}
+    {% if sample.fileType == "fasterq" %}
+      export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+      module load {{ constants.tools.petagene.module }}
+    {% endif %}
 
     rm -r "{{ temp_dir }}" || true
     mkdir -p "{{ temp_dir }}"

--- a/modules/single_cell/main.jst
+++ b/modules/single_cell/main.jst
@@ -15,6 +15,10 @@
       {% set rnaStrandType=file.rnaStrandType|default('unstranded')|lower %}
       {% set rnaStrandDirection=file.rnaStrandDirection|default('notapplicable')|lower %}
       {% set strandedness %}{{ readOrientation }}-{{ rnaStrandType }}-{{ rnaStrandDirection }}{% endset %}
+      {% if file.quantity is defined and file.quantitySource is defined and file.quantitySource|lower == 'cells' %}
+        {% set expectedCells=file.quantity %}
+        {% do file.update({'expectedCells': expectedCells}) %}
+      {% endif %}
       {% do file.update({'strandedness': strandedness}) %}
     {% endfor %}
 

--- a/modules/single_cell/starsolo.jst
+++ b/modules/single_cell/starsolo.jst
@@ -53,6 +53,13 @@
 
     module load {{ constants.tools.star.module }}
     module load {{ constants.tools.samtools.module }}
+    {% for fq in files %}
+      {% if fq.fileType == "fasterq" and petagene not defined %}
+        export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+        module load {{ constants.tools.petagene.module }}
+        {% set petagene=true %}
+      {% endif %}
+    {% endfor %}
 
     rm -r "{{ temp_dir }}" || true
     mkdir -p "{{ temp_dir }}"

--- a/modules/single_cell/starsolo.jst
+++ b/modules/single_cell/starsolo.jst
@@ -53,13 +53,10 @@
 
     module load {{ constants.tools.star.module }}
     module load {{ constants.tools.samtools.module }}
-    {% for fq in files %}
-      {% if fq.fileType == "fasterq" and petagene not defined %}
-        export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
-        module load {{ constants.tools.petagene.module }}
-        {% set petagene=true %}
-      {% endif %}
-    {% endfor %}
+    {% if sample.fileType == "fasterq" %}
+      export PetaLinkMode="{{ constants.tools.petagene.PetaLinkMode }}"
+      module load {{ constants.tools.petagene.module }}
+    {% endif %}
 
     rm -r "{{ temp_dir }}" || true
     mkdir -p "{{ temp_dir }}"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -38,9 +38,9 @@ constants:
         Li H. and Durbin R. (2009) Fast and accurate short read alignment with Burrows-Wheeler Transform.
         Bioinformatics, 25:1754-60. [PMID: 19451168]
     cellranger:
-      module: cellranger/3.1.0
-      version: "3.1.0"
-      verbose: 10X CellRanger v3.1.0
+      module: cellranger/6.0.0
+      version: "6.0.0"
+      verbose: 10X CellRanger v6.0.0
       website: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
       citation: >
         TODO
@@ -426,29 +426,29 @@ constants:
     stats2json: samStats2json_3a90a2f.py
     stats2lims: uploadStats2Lims_1ace81f.py
     annotSeg_script: annotSeg_8820499.pl
-    cellranger_reference: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/gene_model/ensembl_v98/tool_resources/cellranger_3.1.0/hg38tgen_ensembl_v98
-    cellranger_vdj_reference: /home/tgenref/homo_sapiens/grch38_hg38/tool_specific_resources/cellranger/refdata-cellranger-vdj-GRCh38-alts-ensembl-3.1.0
+    cellranger_reference: /home/tgenref/homo_sapiens/grch38_hg38/hg38tgen/gene_model/ensembl_v98/tool_resources/cellranger_6.0.0/hg38tgen_ensembl_v98
+    cellranger_vdj_reference: /home/tgenref/homo_sapiens/grch38_hg38/tool_specific_resources/cellranger/refdata-cellranger-vdj-GRCh38-alts-ensembl-5.0.0
     scrna_chemistry_options:
       X3SCR:
         chemistry_name: SC3Pv1
         umi_length: 10
-        cell_barcode_whitelist_file: /packages/cellranger/3.1.0/cellranger-cs/3.1.0/lib/python/cellranger/barcodes/737K-april-2014_rc.txt
+        cell_barcode_whitelist_file: /packages/easy-build/software/CellRanger/6.0.0/lib/python/cellranger/barcodes/737K-april-2014_rc.txt
       XCSCR:
         chemistry_name: SC3Pv2
         umi_length: 10
-        cell_barcode_whitelist_file: /packages/cellranger/3.1.0/cellranger-cs/3.1.0/lib/python/cellranger/barcodes/737K-august-2016.txt
+        cell_barcode_whitelist_file: /packages/easy-build/software/CellRanger/6.0.0/lib/python/cellranger/barcodes/737K-august-2016.txt
       X3SC3:
         chemistry_name: SC3Pv3
         umi_length: 12
-        cell_barcode_whitelist_file: /packages/cellranger/3.1.0/cellranger-cs/3.1.0/lib/python/cellranger/barcodes/3M-february-2018.txt
+        cell_barcode_whitelist_file: /packages/easy-build/software/CellRanger/6.0.0/lib/python/cellranger/barcodes/3M-february-2018.txt
       X5SCR:
         chemistry_name: SC5P-R2
         umi_length: 10
-        cell_barcode_whitelist_file: /packages/cellranger/3.1.0/cellranger-cs/3.1.0/lib/python/cellranger/barcodes/737K-august-2016.txt
+        cell_barcode_whitelist_file: /packages/easy-build/software/CellRanger/6.0.0/lib/python/cellranger/barcodes/737K-august-2016.txt
       unknown:
         chemistry_name: auto
         umi_lenth: 10
-        cell_barcode_whitelist_file: /packages/cellranger/3.1.0/cellranger-cs/3.1.0/lib/python/cellranger/barcodes/737K-august-2016.txt
+        cell_barcode_whitelist_file: /packages/easy-build/software/CellRanger/6.0.0/lib/python/cellranger/barcodes/737K-august-2016.txt
     gatk_known_sites:
       - /home/tgenref/homo_sapiens/grch38_hg38/public_databases/broad_resource_bundle/Homo_sapiens_assembly38.dbsnp138.vcf
       - /home/tgenref/homo_sapiens/grch38_hg38/public_databases/broad_resource_bundle/Homo_sapiens_assembly38.known_indels.vcf.gz

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -38,9 +38,9 @@ constants:
         Li H. and Durbin R. (2009) Fast and accurate short read alignment with Burrows-Wheeler Transform.
         Bioinformatics, 25:1754-60. [PMID: 19451168]
     cellranger:
-      module: cellranger/6.0.0
-      version: "6.0.0"
-      verbose: 10X CellRanger v6.0.0
+      module: cellranger/6.0.1
+      version: "6.0.1"
+      verbose: 10X CellRanger v6.0.1
       website: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger
       citation: >
         TODO


### PR DESCRIPTION
Updates cellranger to v6.0.1, resolving issue #403.

This includes support for fasterqs and the usage of --expect-cells, resolving issue #166.

It does not include cellranger multi for now, as that is planned for a future workflow.