### PR TITLE
Temp VCF Filtering

### DIFF
--- a/utilities/variant_filtering.jst
+++ b/utilities/variant_filtering.jst
@@ -71,10 +71,7 @@
 
 {% endmacro %}
 
-{% macro somatic_variant_filter(pair, input_vcf, final_vcf_prefix, temp_dir, variant_caller) %}
-
-{% set output_vcf %}{{ final_vcf_prefix }}.flt.vcf.gz{% endset %}
-{% set temp_vcf_prefix %}{{ temp_dir }}/{{ final_vcf_prefix | basename }}{% endset %}
+{% macro filter_variants(pair, input_vcf, output_vcf, task) %}
 
 {# Checking if CC_filter is already defined, in preparation for allowing user defined filters #}
 {% if CC_filter is not defined %}
@@ -88,10 +85,17 @@
   {% endif %}
 {% endif %}
 
-{# If CC filter is still not defined then we only have one caller and filtering is pointless #}
-{% if CC_filter is defined %}
-- name: somatic_variant_filtering_{{ pair.name }}_{{ variant_caller }}
-  tags: [somatic, variant_filter, {{ variant_caller }}]
+{# Checking for output_vcf type, e.g. vcf.gz, vcf, bcf #}
+{% if output_vcf.endswith('vcf') %}
+  {% set output_type = v %}
+{% elif output_vcf.endswith('bcf') %}
+  {% set output_type = b %}
+{% else %}
+  {% set output_type = z %}
+{% endif %}
+
+- name: variant_filtering_{{ pair.name }}_{{ task }}
+  tags: [variant_filter]
   {% if temp_dir in input_vcf %}
   reset: predecessors
   {% endif %}
@@ -106,16 +110,14 @@
 
     module load {{ constants.tools.bcftools.module }}
 
-    mkdir -p {{ temp_dir }}
-
-    {# We need to do tiered filtering since we can't use -i and -e at the same time #}
     bcftools view \
+      {% if CC_filter is defined %}
       --include "{{ CC_filter }}" \
-      --output-file {{ temp_vcf_prefix }}.filtered_db.vcf.gz \
-      --output-type z \
+      {% endif %}
+      --output-file {{ output_vcf }} \
+      --output-type {{ output_type }} \
       {{ input_vcf }}
 
-    bcftools index --force {{ temp_vcf_prefix}}.filtered_db.vcf.gz
+    bcftools index --force {{ output_vcf }}
 
-{% endif %}
 {% endmacro %}

--- a/utilities/variant_filtering.jst
+++ b/utilities/variant_filtering.jst
@@ -116,6 +116,9 @@
       --output-type {{ output_type }} \
       {{ input_vcf }}
 
+    {# No need to index vcf if it isn't compressed #}
+    {%- if output_type != 'v' %}
     bcftools index --force {{ output_vcf }}
+    {% endif %}
 
 {% endmacro %}

--- a/utilities/variant_filtering.jst
+++ b/utilities/variant_filtering.jst
@@ -86,18 +86,15 @@
 
 {# Checking for output_vcf type, e.g. vcf.gz, vcf, bcf #}
 {% if output_vcf.endswith('vcf') %}
-  {% set output_type = v %}
+  {% set output_type = 'v' %}
 {% elif output_vcf.endswith('bcf') %}
-  {% set output_type = b %}
+  {% set output_type = 'b' %}
 {% else %}
-  {% set output_type = z %}
+  {% set output_type = 'z' %}
 {% endif %}
 
 - name: variant_filtering_{{ pair.name }}_{{ task }}
   tags: [variant_filter]
-  {% if temp_dir in input_vcf %}
-  reset: predecessors
-  {% endif %}
   input: {{ input_vcf }}
   output: {{ output_vcf }}
   cpus: 1

--- a/utilities/variant_filtering.jst
+++ b/utilities/variant_filtering.jst
@@ -70,3 +70,49 @@
     bcftools index --threads 4 --force {{ output_vcf }}
 
 {% endmacro %}
+
+{% macro somatic_variant_filter(pair, input_vcf, final_vcf_prefix, temp_dir, variant_caller) %}
+
+{% set output_vcf %}{{ final_vcf_prefix }}.flt.vcf.gz{% endset %}
+{% set temp_vcf_prefix %}{{ temp_dir }}/{{ final_vcf_prefix | basename }}{% endset %}
+
+{# Checking if CC_filter is already defined, in preparation for allowing user defined filters #}
+{% if CC_filter is not defined %}
+  {% if pair.callers is defined %}
+    {% set num_callers %}{{ pair.callers | length }}{% endset %}
+    {% if num_callers > 3 %}
+      {% set CC_filter %}INFO/CC>={{ pair.callers | length - 2 }}{% endset %}
+    {% else %}
+      {% set CC_filter %}INFO/CC>={{ pair.callers | length - 1 }}{% endset %}
+    {% endif %}
+  {% endif %}
+{% endif %}
+
+- name: somatic_variant_filtering_{{ pair.name }}_{{ variant_caller }}
+  tags: [somatic, variant_filter, {{ variant_caller }}]
+  {% if temp_dir in input_vcf %}
+  reset: predecessors
+  {% endif %}
+  input: {{ input_vcf }}
+  output: {{ output_vcf }}
+  cpus: 1
+  mem: 4G
+  walltime: "4:00:00"
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.bcftools.module }}
+
+    mkdir -p {{ temp_dir }}
+
+    {# We need to do tiered filtering since we can't use -i and -e at the same time #}
+    bcftools view \
+      --include "{{ CC_filter }}" \
+      --output-file {{ temp_vcf_prefix }}.filtered_db.vcf.gz \
+      --output-type z \
+      {{ input_vcf }}
+
+    bcftools index --force {{ temp_vcf_prefix}}.filtered_db.vcf.gz
+
+{% endmacro %}

--- a/utilities/variant_filtering.jst
+++ b/utilities/variant_filtering.jst
@@ -78,7 +78,7 @@
 
 {# Checking if CC_filter is already defined, in preparation for allowing user defined filters #}
 {% if CC_filter is not defined %}
-  {% if pair.callers is defined %}
+  {% if pair.callers is defined and pair.callers|length > 1 %}
     {% set num_callers %}{{ pair.callers | length }}{% endset %}
     {% if num_callers > 3 %}
       {% set CC_filter %}INFO/CC>={{ pair.callers | length - 2 }}{% endset %}
@@ -88,6 +88,8 @@
   {% endif %}
 {% endif %}
 
+{# If CC filter is still not defined then we only have one caller and filtering is pointless #}
+{% if CC_filter is defined %}
 - name: somatic_variant_filtering_{{ pair.name }}_{{ variant_caller }}
   tags: [somatic, variant_filter, {{ variant_caller }}]
   {% if temp_dir in input_vcf %}
@@ -115,4 +117,5 @@
 
     bcftools index --force {{ temp_vcf_prefix}}.filtered_db.vcf.gz
 
+{% endif %}
 {% endmacro %}

--- a/utilities/variant_filtering.jst
+++ b/utilities/variant_filtering.jst
@@ -71,13 +71,12 @@
 
 {% endmacro %}
 
-{% macro filter_variants(pair, input_vcf, output_vcf, task) %}
+{% macro filter_variants(pair, input_vcf, output_dir, output_vcf, task) %}
 
 {# Checking if CC_filter is already defined, in preparation for allowing user defined filters #}
 {% if CC_filter is not defined %}
   {% if pair.callers is defined and pair.callers|length > 1 %}
-    {% set num_callers %}{{ pair.callers | length }}{% endset %}
-    {% if num_callers > 3 %}
+    {% if pair.callers | length > 3 %}
       {% set CC_filter %}INFO/CC>={{ pair.callers | length - 2 }}{% endset %}
     {% else %}
       {% set CC_filter %}INFO/CC>={{ pair.callers | length - 1 }}{% endset %}
@@ -109,6 +108,8 @@
     set -o pipefail
 
     module load {{ constants.tools.bcftools.module }}
+
+    mkdir -p {{ output_dir }}
 
     bcftools view \
       {% if CC_filter is defined %}


### PR DESCRIPTION
A number of tools require a filtered vcf as input, this macro enables the dynamic creation of a filtered vcf based on the number of callers.