### PR TITLE
Feature: VCF Stats

### DIFF
--- a/modules/constitutional/deepvariant.jst
+++ b/modules/constitutional/deepvariant.jst
@@ -1,4 +1,5 @@
 {% from 'modules/annotation/main.jst' import annotate_vcfs with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {%- macro deepvariant(sample, aligner='bwa', taskPrefix='Genome') %}
 
@@ -152,4 +153,7 @@
     bcftools index --tbi --force "{{ pass_vcf }}"
 
 {{- annotate_vcfs(sample, temp_dir, results_dir, pass_vcf, taskPrefix, aligner, 'deepvariant', 'constitutional', 'snp_indel_caller') }}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
+
 {% endmacro %}

--- a/modules/constitutional/freebayes.jst
+++ b/modules/constitutional/freebayes.jst
@@ -1,5 +1,6 @@
 {% from 'modules/annotation/main.jst' import annotate_vcfs with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {%- macro freebayes(sample, aligner='bwa', taskPrefix='Genome') %}
 
@@ -109,4 +110,7 @@
 
 
 {{- annotate_vcfs(sample, temp_dir, results_dir, pass_vcf, taskPrefix, aligner, 'freebayes', 'constitutional', 'snp_indel_caller') }}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
+
 {% endmacro %}

--- a/modules/constitutional/gatk_genotypegvcf.jst
+++ b/modules/constitutional/gatk_genotypegvcf.jst
@@ -1,5 +1,6 @@
 {% from 'modules/annotation/main.jst' import annotate_vcfs with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {%- macro genotypegvcf(sample, aligner='bwa', taskPrefix='Genome') %}
 
@@ -152,5 +153,7 @@
 
 
 {{- annotate_vcfs(sample, temp_dir, results_dir, pass_vcf, taskPrefix, aligner, 'hc', 'constitutional', 'genotype_hc_gvcf') }}
-{% endmacro %}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
 
+{% endmacro %}

--- a/modules/constitutional/octopus.jst
+++ b/modules/constitutional/octopus.jst
@@ -1,5 +1,6 @@
 {% from 'modules/annotation/main.jst' import annotate_vcfs with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {%- macro octopus_constitutional(sample, aligner='bwa', taskPrefix='Genome') %}
 {%- set bam %}{{ sample.gltype }}/alignment/{{ aligner }}/{{ sample.name }}/{{ sample.name }}.{{ aligner }}.bam{% endset %}
@@ -127,4 +128,7 @@
 
 
 {{- annotate_vcfs(sample, temp_dir, results_dir, pass_vcf, taskPrefix, aligner, 'octopus', 'constitutional', 'snp_indel_caller') }}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
+
 {% endmacro -%}

--- a/modules/constitutional/strelka2.jst
+++ b/modules/constitutional/strelka2.jst
@@ -1,5 +1,6 @@
 {% from 'modules/annotation/main.jst' import annotate_vcfs with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {%- macro strelka2_constitutional(sample, aligner='bwa', taskPrefix='Genome') %}
 
@@ -138,4 +139,7 @@
 
 
 {{- annotate_vcfs(sample, temp_dir, results_dir, pass_vcf, taskPrefix, aligner, 'strelka2', 'constitutional', 'snp_indel_caller' ) }}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
+
 {% endmacro %}

--- a/modules/metrics/main.jst
+++ b/modules/metrics/main.jst
@@ -1,5 +1,6 @@
 {%- from 'modules/metrics/mutation_burden.jst' import mutation_burden with context %}
 {%- from 'modules/metrics/msisensor_pro.jst' import msisensor_pro with context %}
+{%- from 'modules/metrics/tucon.jst' import tucon with context %}
 
 {%- macro collect_somatic_metrics(pair, normal_bam, tumor_bam, results_dir, taskPrefix, aligner, variant_caller) %}
 

--- a/modules/metrics/main.jst
+++ b/modules/metrics/main.jst
@@ -57,8 +57,10 @@
     {{- mutation_burden(pair, normal_bam, tumor_bam, final_vcf, variant_caller, aligner, 'vep') }}
   {% endif %}
   {% if tasks[taskPrefix+"_somatic_sample_metric_tucon"]|default(true) %}
+    {% if tasks[taskPrefix+"_"+analysis_type+"_annotate_vcfs_bcftools_topmed"]|default(true) %}
     {% set final_vcf %}{{ final_vcf_prefix }}.vep.full.vcf.gz{% endset %}
     {{- tucon(pair, final_vcf, 'vep') }}
+    {% endif %}
   {% endif %}
 {% endif %}
 {% if flags.snpeff %}
@@ -67,8 +69,10 @@
     {{- mutation_burden(pair, normal_bam, tumor_bam, final_vcf, variant_caller, aligner, 'snpeff') }}
   {% endif %}
   {% if tasks[taskPrefix+"_somatic_sample_metric_tucon"]|default(true) %}
+    {% if tasks[taskPrefix+"_"+analysis_type+"_annotate_vcfs_bcftools_topmed"]|default(true) %}
     {% set final_vcf %}{{ final_vcf_prefix }}.snpeff.full.vcf.gz{% endset %}
     {{- tucon(pair, final_vcf, 'snpeff') }}
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/modules/metrics/main.jst
+++ b/modules/metrics/main.jst
@@ -40,24 +40,34 @@
   {% set flags.vep = true %}
 {% endif %}
 
-{% if tasks[taskPrefix+"_somatic_sample_metric_tgen_mutation_burden"]|default(true) %}
-  {% if flags.bcftools %}
-    {# If pair.normal.pathToBam is defined then we have a tumor_only pair #}
-    {% if pair.normal.pathToBam is defined %}
-      {% set final_vcf_prefix %}{{ vcf_prefix }}.db.flt{% endset %}
-    {% else %}
-      {% set final_vcf_prefix %}{{ vcf_prefix }}.db{% endset %}
-    {% endif %}
+{% if flags.bcftools %}
+  {# If pair.normal.pathToBam is defined then we have a tumor_only pair #}
+  {% if pair.normal.pathToBam is defined %}
+    {% set final_vcf_prefix %}{{ vcf_prefix }}.db.flt{% endset %}
   {% else %}
-    {% set final_vcf_prefix %}{{ vcf_prefix }}{% endset %}
+    {% set final_vcf_prefix %}{{ vcf_prefix }}.db{% endset %}
   {% endif %}
-  {% if flags.vep %}
+{% else %}
+  {% set final_vcf_prefix %}{{ vcf_prefix }}{% endset %}
+{% endif %}
+{% if flags.vep %}
+  {% if tasks[taskPrefix+"_somatic_sample_metric_tgen_mutation_burden"]|default(true) %}
     {% set final_vcf %}{{ final_vcf_prefix }}.vep.pick.vcf.gz{% endset %}
     {{- mutation_burden(pair, normal_bam, tumor_bam, final_vcf, variant_caller, aligner, 'vep') }}
   {% endif %}
-  {% if flags.snpeff %}
+  {% if tasks[taskPrefix+"_somatic_sample_metric_tucon"]|default(true) %}
+    {% set final_vcf %}{{ final_vcf_prefix }}.vep.full.vcf.gz{% endset %}
+    {{- tucon(pair, final_vcf, 'vep') }}
+  {% endif %}
+{% endif %}
+{% if flags.snpeff %}
+  {% if tasks[taskPrefix+"_somatic_sample_metric_tgen_mutation_burden"]|default(true) %}
     {% set final_vcf %}{{ final_vcf_prefix }}.snpeff.can.vcf.gz{% endset %}
     {{- mutation_burden(pair, normal_bam, tumor_bam, final_vcf, variant_caller, aligner, 'snpeff') }}
+  {% endif %}
+  {% if tasks[taskPrefix+"_somatic_sample_metric_tucon"]|default(true) %}
+    {% set final_vcf %}{{ final_vcf_prefix }}.snpeff.all.vcf.gz{% endset %}
+    {{- tucon(pair, final_vcf, 'snpeff') }}
   {% endif %}
 {% endif %}
 

--- a/modules/metrics/main.jst
+++ b/modules/metrics/main.jst
@@ -67,7 +67,7 @@
     {{- mutation_burden(pair, normal_bam, tumor_bam, final_vcf, variant_caller, aligner, 'snpeff') }}
   {% endif %}
   {% if tasks[taskPrefix+"_somatic_sample_metric_tucon"]|default(true) %}
-    {% set final_vcf %}{{ final_vcf_prefix }}.snpeff.all.vcf.gz{% endset %}
+    {% set final_vcf %}{{ final_vcf_prefix }}.snpeff.full.vcf.gz{% endset %}
     {{- tucon(pair, final_vcf, 'snpeff') }}
   {% endif %}
 {% endif %}

--- a/modules/metrics/tucon.jst
+++ b/modules/metrics/tucon.jst
@@ -8,7 +8,7 @@
 {% set filtered_vcf %}{{ temp_dir }}/{{ pair.name }}.flt.vcf.gz{% endset %}
 
 {% set task %}tucon_{{ pair.name }}_{{ annotate_flag }}{% endset %}
-{{- filter_variants(pair, input_vcf, filtered_vcf, task) }}
+{{- filter_variants(pair, input_vcf, temp_dir, filtered_vcf, task) }}
 
 - name: tucon_{{ pair.name }}_{{ annotate_flag }}
   tags: [tucon, {{ annotate_flag }}]
@@ -25,11 +25,13 @@
 
     module load {{ constants.tools.bcftools.module }}
 
+    mkdir -p {{ results_dir }}
+
     echo -e "VCF\tMUTATION_COUNT\tTOPMED_COUNT" > {{ tucon_output }}
 
     VCF_BASE=$(basename {{ filtered_vcf }})
-  	MUT_COUNT=$(bcftools view -H {{ filtered_vcf }} | wc -l)
-  	TOPMED_COUNT=$(bcftools view -H -i 'INFO/TOPMED=1 & INFO/TOPMED_AF>0.00001' {{ filtered_vcf }} | wc -l)
-  	echo -e "${VCF_BASE}\t${MUT_COUNT}\t${TOPMED_COUNT}" >> {{ tucon_output }}
+    MUT_COUNT=$(bcftools view -H {{ filtered_vcf }} | wc -l)
+    TOPMED_COUNT=$(bcftools view -H -i 'INFO/TOPMED=1 & INFO/TOPMED_AF>0.00001' {{ filtered_vcf }} | wc -l)
+    echo -e "${VCF_BASE}\t${MUT_COUNT}\t${TOPMED_COUNT}" >> {{ tucon_output }}
 
 {% endmacro %}

--- a/modules/metrics/tucon.jst
+++ b/modules/metrics/tucon.jst
@@ -4,8 +4,8 @@
 
 {% set temp_dir %}temp/{{ pair.gltype }}/metrics/tucon/{{ pair.name }}{% endset %}
 {% set results_dir %}{{ pair.gltype }}/metrics/tucon/{{ pair.name }}{% endset %}
-{% set tucon_output %}{{ results_dir }}/{{ pair.name }}_tucon.tsv{% endset %}
-{% set filtered_vcf %}{{ temp_dir }}/{{ pair.name }}.{{ annotate_flag }}.flt.vcf.gz{% endset %}
+{% set tucon_output %}{{ results_dir }}/{{ pair.name }}_{{ annotate_flag }}_tucon.tsv{% endset %}
+{% set filtered_vcf %}{{ temp_dir }}/{{ pair.name }}_{{ annotate_flag }}.flt.vcf.gz{% endset %}
 
 {% set task %}tucon_{{ pair.name }}_{{ annotate_flag }}{% endset %}
 {{- filter_variants(pair, input_vcf, temp_dir, filtered_vcf, task) }}

--- a/modules/metrics/tucon.jst
+++ b/modules/metrics/tucon.jst
@@ -5,7 +5,7 @@
 {% set temp_dir %}temp/{{ pair.gltype }}/metrics/tucon/{{ pair.name }}{% endset %}
 {% set results_dir %}{{ pair.gltype }}/metrics/tucon/{{ pair.name }}{% endset %}
 {% set tucon_output %}{{ results_dir }}/{{ pair.name }}_tucon.tsv{% endset %}
-{% set filtered_vcf %}{{ temp_dir }}/{{ pair.name }}.flt.vcf.gz{% endset %}
+{% set filtered_vcf %}{{ temp_dir }}/{{ pair.name }}.{{ annotate_flag }}.flt.vcf.gz{% endset %}
 
 {% set task %}tucon_{{ pair.name }}_{{ annotate_flag }}{% endset %}
 {{- filter_variants(pair, input_vcf, temp_dir, filtered_vcf, task) }}

--- a/modules/metrics/tucon.jst
+++ b/modules/metrics/tucon.jst
@@ -1,0 +1,35 @@
+{% from 'utilities/variant_filtering.jst' import filter_variants with context %}
+
+{% macro tucon(pair, input_vcf, annotate_flag) %}
+
+{% set temp_dir %}temp/{{ pair.gltype }}/metrics/tucon/{{ pair.name }}{% endset %}
+{% set results_dir %}{{ pair.gltype }}/metrics/tucon/{{ pair.name }}{% endset %}
+{% set tucon_output %}{{ results_dir }}/{{ pair.name }}_tucon.tsv{% endset %}
+{% set filtered_vcf %}{{ temp_dir }}/{{ pair.name }}.flt.vcf.gz{% endset %}
+
+{% set task %}tucon_{{ pair.name }}_{{ annotate_flag }}{% endset %}
+{{- filter_variants(pair, input_vcf, filtered_vcf, task) }}
+
+- name: tucon_{{ pair.name }}_{{ annotate_flag }}
+  tags: [tucon, {{ annotate_flag }}]
+  input:
+    - {{ filtered_vcf }}
+  output:
+    - {{ tucon_output }}
+  walltime: "12:00:00"
+  cpus: 1
+  mem: 2G
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.bcftools.module }}
+
+    echo -e "VCF\tMUTATION_COUNT\tTOPMED_COUNT" > {{ tucon_output }}
+
+    VCF_BASE=$(basename {{ filtered_vcf }})
+  	MUT_COUNT=$(bcftools view -H {{ filtered_vcf }} | wc -l)
+  	TOPMED_COUNT=$(bcftools view -H -i 'INFO/TOPMED=1 & INFO/TOPMED_AF>0.00001' {{ filtered_vcf }} | wc -l)
+  	echo -e "${VCF_BASE}\t${MUT_COUNT}\t${TOPMED_COUNT}" >> {{ tucon_output }}
+
+{% endmacro %}

--- a/modules/somatic/lancet.jst
+++ b/modules/somatic/lancet.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro lancet(pair, aligner='bwa') %}
 {% do pair.callers.append('lancet') %}
@@ -136,5 +137,8 @@
       > "{{ pass_vcf }}"
     
     bcftools index --tbi --force "{{ pass_vcf }}"
+
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/somatic/mutect2.jst
+++ b/modules/somatic/mutect2.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro mutect2(pair, aligner='bwa') %}
 {% do pair.callers.append('mutect2') %}
@@ -343,5 +344,7 @@
     {% set task %}mutect2_filter_calls_{{ pair.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
     {{- remove_files(directory,none,task) }}
+    {{- vcf_stats(pass_vcf, results_dir) }}
+    {{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/somatic/octopus.jst
+++ b/modules/somatic/octopus.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro octopus_somatic(pair, aligner='bwa') %}
 {% do pair.callers.append('octopus') %}
@@ -161,6 +162,7 @@
     {% set task %}octopus_merge_chunks_{{ pair.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
     {{- remove_files(directory,none,task) }}
-
+    {{- vcf_stats(pass_vcf, results_dir) }}
+    {{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/somatic/strelka2.jst
+++ b/modules/somatic/strelka2.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro strelka2_somatic(pair, aligner='bwa') %}
 {% do pair.callers.append('strelka2') %}
@@ -12,8 +13,8 @@
 
 - name: strelka2_{{ pair.name }}_{{ aligner }}
   tags: [{{ pair.gltype }}, somatic, snp_indel_caller, strelka2, {{ pair.name }}]
-  methods: > 
-    Somatic variants for {{ pair.name }} ({{ aligner }}) were called with 
+  methods: >
+    Somatic variants for {{ pair.name }} ({{ aligner }}) were called with
     {{ constants.tools.strelka.verbose }}.
   input:
     - {{ normal_bam }}
@@ -166,6 +167,7 @@
     {% set task %}strelka2_filter_variants_{{ pair.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
     {{- remove_files(directory,none,task) }}
-
+    {{- vcf_stats(pass_vcf, results_dir) }}
+    {{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/somatic/vardict.jst
+++ b/modules/somatic/vardict.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro vardict_somatic(pair, aligner='bwa') %}
 {% do pair.callers.append('vardict') %}
@@ -257,5 +258,7 @@
      
     bcftools index --tbi --force "{{ pass_vcf }}"
 
-{% endmacro %}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
 
+{% endmacro %}

--- a/modules/somatic/vcfmerger2.jst
+++ b/modules/somatic/vcfmerger2.jst
@@ -3,6 +3,7 @@
 {% from 'modules/somatic/rna_variant_check.jst' import add_rna_header_to_vcf with context %}
 {% from 'modules/somatic/rna_variant_check.jst' import add_matched_rna with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro vcfmerger2(pair, aligner='bwa', taskPrefix='Genome') %}
 
@@ -155,5 +156,6 @@
   {{- add_rna_header_to_vcf(merged_vcf_gz, output_vcf, pair, aligner , temp_dir)  }}
 {% endif %}
   {{- annotate_vcfs(pair, temp_dir, results_dir, output_vcf, taskPrefix, aligner, 'merged', 'somatic', 'snp_indel_caller') }}
+  {{- vcf_stats(output_vcf, results_dir) }}
   {{- collect_somatic_metrics(pair, normal_bam, tumor_bam, results_dir, taskPrefix, aligner, 'merged') }}
 {% endmacro %}

--- a/modules/tumor_only/deepvariant.jst
+++ b/modules/tumor_only/deepvariant.jst
@@ -1,4 +1,5 @@
 {% from 'modules/annotation/main.jst' import annotate_vcfs with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {%- macro deepvariant_tumor_only(sample, aligner='bwa', taskPrefix='Genome') %}
 
@@ -153,5 +154,7 @@
 
 {# Skipping annotate vcfs step until requested #}
 {# annotate_vcfs(sample, temp_dir, results_dir, pass_vcf, taskPrefix, aligner, 'deepvariant', 'constitutional', 'snp_indel_caller') #}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/tumor_only/lancet.jst
+++ b/modules/tumor_only/lancet.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro lancet_tumor_only(pair, aligner='bwa') %}
 {% do pair.callers.append('lancet') %}
@@ -138,5 +139,8 @@
       > "{{ pass_vcf }}"
     
     bcftools index --tbi --force "{{ pass_vcf }}"
+
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/tumor_only/mutect2.jst
+++ b/modules/tumor_only/mutect2.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro mutect2_tumor_only(pair, aligner='bwa') %}
 {% do pair.callers.append('mutect2') %}
@@ -351,5 +352,7 @@
     {% set task %}tumor_only_mutect2_filter_variants_{{ pair.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
     {{- remove_files(directory,none,task) }}
+    {{- vcf_stats(pass_vcf, results_dir) }}
+    {{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/tumor_only/octopus.jst
+++ b/modules/tumor_only/octopus.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro octopus_tumor_only(pair, aligner='bwa') %}
 {% do pair.callers.append('octopus') %}
@@ -167,6 +168,7 @@
     {% set task %}tumor_only_octopus_filter_variants_{{ pair.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
     {{- remove_files(directory,none,task) }}
-
+    {{- vcf_stats(pass_vcf, results_dir) }}
+    {{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/tumor_only/strelka2.jst
+++ b/modules/tumor_only/strelka2.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro strelka2_tumor_only(pair, aligner='bwa') %}
 {% do pair.callers.append('strelka2') %}
@@ -168,6 +169,7 @@
     {% set task %}tumor_only_strelka2_filter_variants_{{ pair.name }}_{{ aligner }}{% endset %}
     {% set directory %}{{ temp_dir }}{% endset %}
     {{- remove_files(directory,none,task) }}
-
+    {{- vcf_stats(pass_vcf, results_dir) }}
+    {{- vcf_stats(all_vcf, results_dir) }}
 
 {% endmacro %}

--- a/modules/tumor_only/vardict.jst
+++ b/modules/tumor_only/vardict.jst
@@ -1,4 +1,5 @@
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro vardict_tumor_only(pair, aligner='bwa') %}
 {% do pair.callers.append('vardict') %}
@@ -263,5 +264,7 @@
      
     bcftools index --tbi --force "{{ pass_vcf }}"
 
-{% endmacro %}
+{{- vcf_stats(pass_vcf, results_dir) }}
+{{- vcf_stats(all_vcf, results_dir) }}
 
+{% endmacro %}

--- a/modules/tumor_only/vcfmerger2.jst
+++ b/modules/tumor_only/vcfmerger2.jst
@@ -3,6 +3,7 @@
 {% from 'modules/tumor_only/rna_variant_check.jst' import add_rna_header_to_vcf with context %}
 {% from 'modules/tumor_only/rna_variant_check.jst' import add_matched_rna with context %}
 {% from 'utilities/remove_files.jst' import remove_files with context %}
+{% from 'utilities/vcf_stats.jst' import vcf_stats with context %}
 
 {% macro vcfmerger2_tumor_only(pair, aligner='bwa', taskPrefix='Genome') %}
 
@@ -165,5 +166,6 @@
   {{- add_rna_header_to_vcf(merged_vcf_gz, output_vcf, pair, aligner , temp_dir) }}
 {% endif %}
   {{- annotate_vcfs(pair, temp_dir, results_dir, output_vcf, taskPrefix, aligner, 'merged', 'tumor_only', 'snp_indel_caller') }}
+  {{- vcf_stats(output_vcf, results_dir) }}
   {{- collect_somatic_metrics(pair, normal_bam, tumor_bam, results_dir, taskPrefix, aligner, 'merged') }}
 {% endmacro %}

--- a/utilities/vcf_stats.jst
+++ b/utilities/vcf_stats.jst
@@ -1,9 +1,9 @@
 {% macro vcf_stats(input_vcf, results_dir) %}
 
-- name: bcftools_stats_{{ input_vcf.basename | replace(".", "_") }}
-  tags: [bcftools, stats, ]
+- name: bcftools_stats_{{ input_vcf | basename | replace(".", "_") }}
+  tags: [bcftools, stats, vcf]
   input: {{ input_vcf }}
-  output: {{ results_dir }}/stats/{{ output_vcf_stats }}
+  output: {{ results_dir }}/stats/{{ input_vcf | basename }}.stats.txt
   cpus: 1
   walltime: "4:00:00"
   cmd: |
@@ -16,6 +16,6 @@
 
     bcftools stats \
       {{ input_vcf }} \
-      > {{ results_dir }}/stats/{{ input_vcf.basename }}.stats.txt
+      > {{ results_dir }}/stats/{{ input_vcf | basename }}.stats.txt
 
 {% endmacro %}

--- a/utilities/vcf_stats.jst
+++ b/utilities/vcf_stats.jst
@@ -1,0 +1,21 @@
+{% macro vcf_stats(input_vcf, results_dir) %}
+
+- name: bcftools_stats_{{ input_vcf.basename | replace(".", "_") }}
+  tags: [bcftools, stats, ]
+  input: {{ input_vcf }}
+  output: {{ results_dir }}/stats/{{ output_vcf_stats }}
+  cpus: 1
+  walltime: "4:00:00"
+  cmd: |
+    set -eu
+    set -o pipefail
+
+    module load {{ constants.tools.bcftools.module }}
+
+    mkdir -p {{ results_dir }}/stats
+
+    bcftools stats \
+      {{ input_vcf }} \
+      > {{ results_dir }}/stats/{{ input_vcf.basename }}.stats.txt
+
+{% endmacro %}


### PR DESCRIPTION
This resolves a couple of issues: #317 and #366

Overall changes here include new stats for the variant callers where useful. Also adding the stat creation for TuCon.

Let me know if we'd like some more granular output for TuCon, e.g. incorporating the processing already completed for processing the data in R. 

In particular:
```R
mut_summary <- muts %>% select(CHROM, POS, ALT, REF, TOPMED, GNOMAD_GENOME) %>% 
  unique() %>% 
  summarise(Total_Mutations = n(), 
            TOPMED_Count = sum(if_else(TOPMED == 1, 1, 0)), 
            GNOMAD_Count = sum(if_else(GNOMAD_GENOME == 1, 1, 0))) %>% 
  mutate(TOPMED_Freq = TOPMED_Count / Total_Mutations, 
         GNOMAD_Freq = GNOMAD_Count / Total_Mutations) %>% 
  add_column(Sample = opt$sampleName)

# Write out summary file
mut_summary_name <- paste(opt$sampleName, ".flt.mutTable.summary.tsv", sep = "")
write_tsv(mut_summary, mut_summary_name)

# Allele freq distribution check
mut_graph <- muts %>% select(CHROM, POS, ALT, REF, TOPMED, GNOMAD_GENOME, Tumor_AR) %>% 
  unique()

ggplot(mut_graph, aes(TOPMED, Tumor_AR)) + 
  geom_boxplot() + 
  geom_jitter(width = 0.2)
ggsave(paste(opt$sampleName, ".flt.mutTable.summary.TOPMED.png", sep = ""))

ggplot(mut_graph, aes(GNOMAD_GENOME, Tumor_AR)) + 
  geom_boxplot() + 
  geom_jitter(width = 0.2)
ggsave(paste(opt$sampleName, ".flt.mutTable.summary.GNOMAD.png", sep = ""))

ggplot(muts, aes(Tumor_AR)) + 
  geom_histogram(binwidth = 0.01)
```

With obvious changes for working with only TOPMED.