### PR TITLE
The index files for md5sum bam/cram are also needed as input

### DIFF
--- a/utilities/md5sum_bam_cram.jst
+++ b/utilities/md5sum_bam_cram.jst
@@ -8,8 +8,10 @@
   input:
     {% if cram|default(true) %}
     - {{ file_path }}/{{ sample.name }}.{{ aligner }}.cram
+    - {{ file_path }}/{{ sample.name }}.{{ aligner }}.crai
     {% else %}
     - {{ file_path }}/{{ sample.name }}.{{ aligner }}.bam
+    - {{ file_path }}/{{ sample.name }}.{{ aligner }}.bam.bai
     {% endif %}
   output:
     {% if cram|default(true) %}


### PR DESCRIPTION
Adding alignment indexes as input to md5sum bam/cram