### PR TITLE
Updates for UMI alignment workflow and gammit changes

### DIFF
--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -173,7 +173,7 @@
   tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, umi, {{ sample.name }}]
   reset: predecessors
   input:
-    - {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
+    - {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam
     - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt
@@ -190,7 +190,7 @@
     fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp \
       --compression 1 --async-io \
       GroupReadsByUmi \
-      --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam \
+      --input {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam \
       --strategy paired \
       --allow-inter-contig true \
       --family-size-histogram {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt \
@@ -198,13 +198,13 @@
       --assign-tag MI \
       --edits 1 \
       --min-map-q 20 \
-      --output {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam
+      --output {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa_gd.bam
 
     {# Collapse single read families (review parameters) #}
     fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp \
       --compression 1 \
       CallMolecularConsensusReads \
-      --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam \
+      --input {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa_gd.bam \
       --threads 4 \
       --min-reads 1 \
       --tag MI \

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -49,7 +49,7 @@
     {# Extract UMI from reads and create uBAM (Step 1 - One step with fgbio)
     ## Need read structure to be dynamic by UMI kit and reads performed #}
     fgbio --tmp-dir {{ temp_dir }}/{{ rgid }}/fgbio_tmp \
-      -Xmx1g --compression 0 \
+      --compression 0 \
       FastqToBam \
         --input {% for fastq in [r1fastq, r2fastq] %}temp/fastqs/{{ fastq.basename }} {% endfor %} \
         --read-structure 5M2S+T 5M2S+T \
@@ -63,7 +63,7 @@
         --sequencing-center {{ sample.rgcn }} \
         --output /dev/stdout | \
       fgbio --tmp-dir {{ temp_dir }}/{{ rgid }}/fgbio_tmp \
-        -Xmx2g --compression 1 --async-io \
+        --compression 1 --async-io \
         CorrectUmis \
         --input /dev/stdin \
         --output {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam \
@@ -145,7 +145,7 @@
       -t 10 \
       {{ constants.phoenix.bwa_mem2_index }} \
       /dev/stdin |\
-    fgbio -Xmx4g --compression 1 --async-io ZipperBams \
+    fgbio --compression 1 --async-io ZipperBams \
       --unmapped {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
       --ref {{ constants.phoenix.reference_fasta }} \
       --output {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
@@ -188,10 +188,11 @@
 
     {# Group Reads by UMI (This does not need to be sort, it sorts by UMI, then 5' end, then those with matching 3' are tagged) #}
     fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp \
-      -Xmx8g --compression 1 --async-io \
+      --compression 1 --async-io \
       GroupReadsByUmi \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam \
       --strategy paired \
+      --allow-inter-contig true \
       --family-size-histogram {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt \
       --raw-tag RX \
       --assign-tag MI \
@@ -201,7 +202,7 @@
 
     {# Collapse single read families (review parameters) #}
     fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp \
-      -Xmx4g --compression 1 \
+      --compression 1 \
       CallMolecularConsensusReads \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam \
       --threads 4 \
@@ -247,7 +248,7 @@
       -t 10 \
       {{ constants.phoenix.bwa_mem2_index }} \
       /dev/stdin |\
-    fgbio -Xmx4g --compression 1 --async-io ZipperBams \
+    fgbio --compression 1 --async-io ZipperBams \
       --unmapped  {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam \
       --ref {{ constants.phoenix.reference_fasta }} \
       --tags-to-reverse Consensus \

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -173,6 +173,8 @@
 
     KNOWN_UMI=/home/tgenref/assay_files/twist_umi_adaptor_system/known_umi_sequences.txt
 
+    mkdir -p {{ results_dir }}/stats
+
     {#
     # Correct the UMI sequences (those that don't match expected UMI after correction are removed)
     # the known umi would need to be dynamic by kit ultimately
@@ -184,7 +186,7 @@
       --umi-files ${KNOWN_UMI} \
       --max-mismatches 2 \
       --min-distance 1 \
-      --metrics {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.txt \
+      --metrics {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt \
       --output {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
 
 
@@ -210,7 +212,7 @@
     fgbio GroupReadsByUmi \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam \
       --strategy paired \
-      --family-size-histogram {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt \
+      --family-size-histogram {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt \
       --raw-tag RX \
       --assign-tag MI \
       --edits 1 \
@@ -243,7 +245,7 @@
     set -eu
     set -o pipefail
 
-    module load {{ constants.tools.bwa.module }}
+    module load {{ constants.tools.bwa_mem2.module }}
     module load {{ constants.tools.gatk.module }}
 
     {# Align UMI collapsed single read families
@@ -255,13 +257,13 @@
       --INPUT {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam \
       --FASTQ /dev/stdout \
       --INTERLEAVE true |\
-    bwa mem \
+    bwa-mem2 mem \
       -v 3 \
       -Y \
       -K 100000000 \
       -p \
       -t 10 \
-      {{ constants.phoenix.bwa_index }} \
+      {{ constants.phoenix.bwa_mem2_index }} \
       /dev/stdin |\
     gatk MergeBamAlignment \
       --ALIGNED_BAM /dev/stdin \

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -39,12 +39,12 @@
     {#
       This comment is here for protect render spacing, do not remove.
     #}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}"
+    rm -r {{ temp_dir }}/{{ rgid }} || true
+    mkdir -p {{ temp_dir }}/{{ rgid }}
 
     {# Extract UMI from reads and create uBAM (Step 1 - One step with fgbio)
     ## Need read structure to be dynamic by UMI kit and reads performed #}
-    fgbio FastqToBam \
+    fgbio --tmp-dir {{ temp_dir }}/{{ rgid }}/fgbio_tmp FastqToBam \
         --input {% for fastq in [r1fastq, r2fastq] %}temp/fastqs/{{ fastq.basename }} {% endfor %} \
         --read-structure 5M2S+T 5M2S+T \
         --umi-tag RX \
@@ -185,7 +185,7 @@
     # the known umi would need to be dynamic by kit ultimately
     # need to test and optimize max-mismatches and min-distance by UMI format (this worked but need to know best for length and umi number)
     #}
-    fgbio CorrectUmis \
+    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp CorrectUmis \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam \
       --umi-tag RX \
       --umi-files ${KNOWN_UMI} \
@@ -216,7 +216,7 @@
     module load {{ constants.tools.fgbio.module }}
 
     {# Group Reads by UMI (This does not need to be sort, it sorts by UMI, then 5' end, then those with matching 3' are tagged) #}
-    fgbio GroupReadsByUmi \
+    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp GroupReadsByUmi \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam \
       --strategy paired \
       --family-size-histogram {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt \
@@ -227,7 +227,7 @@
       --output {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam
 
     {# Collapse single read families (review parameters) #}
-    fgbio CallMolecularConsensusReads \
+    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp CallMolecularConsensusReads \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam \
       --min-reads 1 \
       --tag MI \

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -22,7 +22,8 @@
     {% endfor %}
   output: 
     - {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam
-  cpus: 10
+  cpus: 4
+  mem: 32G
   walltime: "4:00:00"
   cmd: |
     set -eu
@@ -71,7 +72,8 @@
     {% endfor %}
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
-  cpus: 10
+  cpus: 8
+  mem: 16G
   walltime: "4:00:00"
   cmd: |
     set -eu
@@ -107,6 +109,7 @@
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
   cpus: 10
+  mem: 32G
   walltime: "4:00:00"
   cmd: |
     set -eu
@@ -164,7 +167,8 @@
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
     - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt
-  cpus: 10
+  cpus: 4
+  mem: 32G
   walltime: "4:00:00"
   cmd: |
     set -eu
@@ -202,7 +206,8 @@
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam
     - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt
-  cpus: 10
+  cpus: 4
+  mem: 32G
   walltime: "4:00:00"
   cmd: |
     set -eu
@@ -242,6 +247,7 @@
   output:
     - {{ temp_dir }}/{{ sample.name }}.bwa.md.bam
   cpus: 10
+  mem: 32G
   walltime: "4:00:00"
   cmd: |
     set -eu

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -163,6 +163,7 @@
     - {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
+    - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt
   cpus: 10
   walltime: "4:00:00"
   cmd: |
@@ -200,6 +201,7 @@
     - {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
   output:
     - {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam
+    - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt
   cpus: 10
   walltime: "4:00:00"
   cmd: |

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -208,7 +208,7 @@
     - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt
   cpus: 4
   mem: 32G
-  walltime: "4:00:00"
+  walltime: "24:00:00"
   cmd: |
     set -eu
     set -o pipefail

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -56,11 +56,44 @@
         --sort true \
         --output {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
 
+
+{% endfor %}
+
 {## Need a process to merge uBAM together if there are multiple FASTQ
 ## If uBAM are merged then we should have a chunk process to produce 50M chunks (uBAM interleaved so 100M) for alignment
+#}
+- name: merge_uBAM_{{ sample.name }}
+  tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, umi, {{ sample.name }}]
+  reset: predecessors
+  input:
+    {% for rgid in sample.read_groups %}
+    - {{ temp_dir }}/{{ sample.rgid }}_UMI_uBAM.bam 
+    {% endfor %}
+  output:
+    - {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
+  cpus: 10
+  walltime: "4:00:00"
+  cmd: |
+    set -eu
+    set -o pipefail
 
+    module load {{ constants.tools.samtools.module }}
 
-# Align reads
+    samtools merge \
+      --threads 8 \
+      -c \
+      -f \
+      -l 6 \
+      {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
+    {% for rgid in sample.read_groups %}
+      {% if not loop.last %}
+      {{ temp_dir }}/{{ sample.rgid }}_UMI_uBAM.bam \
+      {% else %}
+      {{ temp_dir }}/{{ sample.rgid }}_UMI_uBAM.bam
+      {% endif %}
+    {% endfor %}
+
+{# Align reads
 ## output is queryname file as it seems like this is needed for best optical duplicate determination by picard markdup
 ## because fgbio ultimately sorts by UMI then location 5' and 3' not clear sorted output helps
 ### All this should be tested in profiling optimization
@@ -79,20 +112,20 @@
     set -eu
     set -o pipefail
 
-    module load {{ constants.tools.bwa.module }}
+    module load {{ constants.tools.bwa_mem2.module }}
     module load {{ constants.tools.gatk.module }}
 
     gatk SamToFastq \
       --INPUT {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
       --FASTQ /dev/stdout \
       --INTERLEAVE true |\
-    bwa mem \
+    bwa-mem2 mem \
       -v 3 \
       -Y \
       -K 100000000 \
       -p \
       -t 10 \
-      {{ constants.phoenix.bwa_index }} \
+      {{ constants.phoenix.bwa_mem2_index }} \
       /dev/stdin |\
     gatk MergeBamAlignment \
       --ALIGNED_BAM /dev/stdin \
@@ -243,7 +276,5 @@
       --CREATE_INDEX true \
       --TMP_DIR {{ temp_dir }} \
       --OUTPUT {{ temp_dir }}/{{ sample.name }}.bwa.md.bam
-
-{% endfor %}
 
 {% endmacro %}

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -253,6 +253,12 @@
       --ref {{ constants.phoenix.reference_fasta }} \
       --tags-to-reverse Consensus \
       --tags-to-revcomp Consensus \
-      --output {{ temp_dir }}/{{ sample.name }}.bwa.md.bam
+      --output {{ temp_dir }}/{{ sample.name }}.bwa.uns.bam
+
+    samtools sort \
+      --threads 10 \
+      -o {{ temp_dir }}/{{ sample.name }}.bwa.md.bam \
+      --write-index \
+      {{ temp_dir }}/{{ sample.name }}.bwa.uns.bam
 
 {% endmacro %}

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -22,6 +22,7 @@
     {% endfor %}
   output: 
     - {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam
+    - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt
   cpus: 4
   mem: 32G
   walltime: "4:00:00"
@@ -41,10 +42,15 @@
     #}
     rm -r {{ temp_dir }}/{{ rgid }} || true
     mkdir -p {{ temp_dir }}/{{ rgid }}
+    mkdir -p {{ results_dir }}/stats
+
+    KNOWN_UMI=/home/tgenref/assay_files/twist_umi_adaptor_system/known_umi_sequences.txt
 
     {# Extract UMI from reads and create uBAM (Step 1 - One step with fgbio)
     ## Need read structure to be dynamic by UMI kit and reads performed #}
-    fgbio --tmp-dir {{ temp_dir }}/{{ rgid }}/fgbio_tmp FastqToBam \
+    fgbio --tmp-dir {{ temp_dir }}/{{ rgid }}/fgbio_tmp \
+      -Xmx1g --compression 0 \
+      FastqToBam \
         --input {% for fastq in [r1fastq, r2fastq] %}temp/fastqs/{{ fastq.basename }} {% endfor %} \
         --read-structure 5M2S+T 5M2S+T \
         --umi-tag RX \
@@ -55,8 +61,18 @@
         --platform-unit {{ sample.rgpu }} \
         --platform-model {{ sample.rgpm }} \
         --sequencing-center {{ sample.rgcn }} \
-        --sort true \
-        --output {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam
+        --output /dev/stdout | \
+      fgbio --tmp-dir {{ temp_dir }}/{{ rgid }}/fgbio_tmp \
+        -Xmx2g --compression 1 --async-io \
+        CorrectUmis \
+        --input /dev/stdin \
+        --output {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam \
+        --max-mismatches 1 \
+        --min-distance 2 \
+        --umi-tag RX \
+        --umi-files ${KNOWN_UMI} \
+        --dont-store-original-umis \
+        --metrics {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt
 
 {% endfor %}
 
@@ -115,13 +131,12 @@
     set -eu
     set -o pipefail
 
+    module load {{ constants.tools.samtools.module }}
     module load {{ constants.tools.bwa_mem2.module }}
-    module load {{ constants.tools.gatk.module }}
+    module load {{ constants.tools.fgbio.module }}
 
-    gatk SamToFastq \
-      --INPUT {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
-      --FASTQ /dev/stdout \
-      --INTERLEAVE true |\
+    samtools fastq \
+      {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam |\
     bwa-mem2 mem \
       -v 3 \
       -Y \
@@ -130,18 +145,10 @@
       -t 10 \
       {{ constants.phoenix.bwa_mem2_index }} \
       /dev/stdin |\
-    gatk MergeBamAlignment \
-      --ALIGNED_BAM /dev/stdin \
-      --UNMAPPED {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
-      --REFERENCE_SEQUENCE {{ constants.phoenix.reference_fasta }} \
-      --EXPECTED_ORIENTATIONS FR \
-      --ALIGNER_PROPER_PAIR_FLAGS true \
-      --ADD_MATE_CIGAR true \
-      --CLIP_OVERLAPPING_READS true \
-      --MAX_INSERTIONS_OR_DELETIONS -1 \
-      --SORT_ORDER queryname \
-      --TMP_DIR {{ temp_dir }} \
-      --OUTPUT {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
+    fgbio -Xmx4g --compression 1 --async-io ZipperBams \
+      --unmapped {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
+      --ref {{ constants.phoenix.reference_fasta }} \
+      --output {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
 
 
 {# Testing showed the expected increase in coverage using UMI aware duplicate marking by 7-20%
@@ -157,45 +164,9 @@
 ### Based on testing and getting most value from the approach I suggest using UMI correction with
 # single read family collapsing to maximize coverage and read accuracy
 
-#### This is the streamlined steps to produce such a result...#}
+#### This is the streamlined steps to produce such a result...
 
-- name: fgbio_correct_umi_{{ sample.name }}
-  tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, umi, {{ sample.name }}]
-  reset: predecessors
-  input:
-    - {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam
-  output:
-    - {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
-    - {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt
-  cpus: 4
-  mem: 32G
-  walltime: "4:00:00"
-  cmd: |
-    set -eu
-    set -o pipefail
-
-    module load {{ constants.tools.fgbio.module }}
-
-    KNOWN_UMI=/home/tgenref/assay_files/twist_umi_adaptor_system/known_umi_sequences.txt
-
-    mkdir -p {{ results_dir }}/stats
-
-    {#
-    # Correct the UMI sequences (those that don't match expected UMI after correction are removed)
-    # the known umi would need to be dynamic by kit ultimately
-    # need to test and optimize max-mismatches and min-distance by UMI format (this worked but need to know best for length and umi number)
-    #}
-    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp CorrectUmis \
-      --input {{ temp_dir }}/{{ sample.rgsm }}_UMI_bwa.bam \
-      --umi-tag RX \
-      --umi-files ${KNOWN_UMI} \
-      --max-mismatches 2 \
-      --min-distance 1 \
-      --metrics {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa.txt \
-      --output {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam
-
-
-{##################################
+##################################
 ## Corrected UMIs - With Single Read Error Correction #}
 
 - name: fgbio_consensus_reads_{{ sample.name }}
@@ -216,7 +187,9 @@
     module load {{ constants.tools.fgbio.module }}
 
     {# Group Reads by UMI (This does not need to be sort, it sorts by UMI, then 5' end, then those with matching 3' are tagged) #}
-    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp GroupReadsByUmi \
+    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp \
+      -Xmx8g --compression 1 --async-io \
+      GroupReadsByUmi \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa.bam \
       --strategy paired \
       --family-size-histogram {{ results_dir }}/stats/{{ sample.rgsm }}_UMIcorr_bwa_gd_hist.txt \
@@ -227,8 +200,11 @@
       --output {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam
 
     {# Collapse single read families (review parameters) #}
-    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp CallMolecularConsensusReads \
+    fgbio --tmp-dir {{ temp_dir }}/fgbio_tmp \
+      -Xmx4g --compression 1 \
+      CallMolecularConsensusReads \
       --input {{ temp_dir }}/{{ sample.rgsm }}_UMIcorr_bwa_gd.bam \
+      --threads 4 \
       --min-reads 1 \
       --tag MI \
       --error-rate-pre-umi 45 \
@@ -253,18 +229,16 @@
     set -eu
     set -o pipefail
 
+    module load {{ constants.tools.samtools.module }}
     module load {{ constants.tools.bwa_mem2.module }}
-    module load {{ constants.tools.gatk.module }}
+    module load {{ constants.tools.fgbio.module }}
 
     {# Align UMI collapsed single read families
     ## This produces a final BAM that is ready for metrics and variant calling
     ## DUPLICATE MARKING IS NOT REQUIRED, as they are removed in previous steps
     ## For QC might want duplicate numbers on the original BAM ({{ sample.rgsm }}_UMI_bwa.bam)
     ## For speed should move to bwa-mem2 #}
-    gatk SamToFastq \
-      --INPUT {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam \
-      --FASTQ /dev/stdout \
-      --INTERLEAVE true |\
+    samtools fastq {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam |\
     bwa-mem2 mem \
       -v 3 \
       -Y \
@@ -273,18 +247,11 @@
       -t 10 \
       {{ constants.phoenix.bwa_mem2_index }} \
       /dev/stdin |\
-    gatk MergeBamAlignment \
-      --ALIGNED_BAM /dev/stdin \
-      --UNMAPPED {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam \
-      --REFERENCE_SEQUENCE {{ constants.phoenix.reference_fasta }} \
-      --EXPECTED_ORIENTATIONS FR \
-      --ALIGNER_PROPER_PAIR_FLAGS true \
-      --ADD_MATE_CIGAR true \
-      --CLIP_OVERLAPPING_READS true \
-      --MAX_INSERTIONS_OR_DELETIONS -1 \
-      --SORT_ORDER coordinate \
-      --CREATE_INDEX true \
-      --TMP_DIR {{ temp_dir }} \
-      --OUTPUT {{ temp_dir }}/{{ sample.name }}.bwa.md.bam
+    fgbio -Xmx4g --compression 1 --async-io ZipperBams \
+      --unmapped  {{ temp_dir }}/{{ sample.rgsm }}_con_uBAM.bam \
+      --ref {{ constants.phoenix.reference_fasta }} \
+      --tags-to-reverse Consensus \
+      --tags-to-revcomp Consensus \
+      --output {{ temp_dir }}/{{ sample.name }}.bwa.md.bam
 
 {% endmacro %}

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -5,12 +5,13 @@
 # This macro splits large fastqs into chunks prior to aligning.
 # If fastq is less than reads_per_chunk (48000000) then one chunk is made.
 {% macro fgbio_bwa_mem(sample) %}
-{% for rgid, rg in sample.read_groups.items() %}
-{% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
-{% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
 
 {% set temp_dir %}temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}{% endset %}
 {% set results_dir %}{{ sample.gltype }}/alignment/bwa/{{ sample.name }}{% endset %}
+
+{% for rgid, rg in sample.read_groups.items() %}
+{% set r1fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R1')|first %}
+{% set r2fastq = rg.data_files|selectattr('fastqCode', 'eq', 'R2')|first %}
 
 - name: create_uBAM_{{ r1fastq.basename | replace(".", "_") }}
   tags: [{{ sample.gltype }}, alignment, dna_alignment, bwa, umi, {{ sample.name }}]
@@ -37,8 +38,8 @@
     {#
       This comment is here for protect render spacing, do not remove.
     #}
-    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/" || true
-    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/"
+    rm -r "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}" || true
+    mkdir -p "temp/{{ sample.gltype }}/alignment/bwa/{{ sample.name }}/{{ rgid }}"
 
     {# Extract UMI from reads and create uBAM (Step 1 - One step with fgbio)
     ## Need read structure to be dynamic by UMI kit and reads performed #}
@@ -54,8 +55,7 @@
         --platform-model {{ sample.rgpm }} \
         --sequencing-center {{ sample.rgcn }} \
         --sort true \
-        --output {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
-
+        --output {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam
 
 {% endfor %}
 
@@ -67,10 +67,10 @@
   reset: predecessors
   input:
     {% for rgid in sample.read_groups %}
-    - {{ temp_dir }}/{{ sample.rgid }}_UMI_uBAM.bam 
+    - {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam 
     {% endfor %}
   output:
-    - {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
+    - {{ temp_dir }}/{{ rgid }}/{{ sample.rgsm }}_UMI_uBAM.bam
   cpus: 10
   walltime: "4:00:00"
   cmd: |
@@ -87,9 +87,9 @@
       {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam \
     {% for rgid in sample.read_groups %}
       {% if not loop.last %}
-      {{ temp_dir }}/{{ sample.rgid }}_UMI_uBAM.bam \
+      {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam \
       {% else %}
-      {{ temp_dir }}/{{ sample.rgid }}_UMI_uBAM.bam
+      {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam
       {% endif %}
     {% endfor %}
 

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -70,7 +70,7 @@
     - {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam 
     {% endfor %}
   output:
-    - {{ temp_dir }}/{{ rgid }}/{{ sample.rgsm }}_UMI_uBAM.bam
+    - {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
   cpus: 10
   walltime: "4:00:00"
   cmd: |

--- a/modules/dna_alignment/fgbio_umi.jst
+++ b/modules/dna_alignment/fgbio_umi.jst
@@ -21,7 +21,7 @@
     - temp/fastqs/{{ fastq.basename }}
     {% endfor %}
   output: 
-    - {{ temp_dir }}/{{ sample.rgsm }}_UMI_uBAM.bam
+    - {{ temp_dir }}/{{ rgid }}/{{ sample.rgid }}_UMI_uBAM.bam
   cpus: 10
   walltime: "4:00:00"
   cmd: |

--- a/modules/tumor_only/mm_igtx_calling.jst
+++ b/modules/tumor_only/mm_igtx_calling.jst
@@ -79,7 +79,9 @@
 - name: discordant_loci_extraction_{{ tumor.name }}
   tags: [assembly,]
   input: {{ tumor_bam }}
-  output: {{ results_dir }}/{{ tumor.name }}_list_of_fastqs.txt
+  output: 
+    - {{ results_dir }}/{{ tumor.name }}_list_of_fastqs.txt
+    - {{ results_dir }}/{{ tumor.name }}_fastqs.tar.gz
   walltime: "12:00:00"
   cpus: 4
   mem: 8G
@@ -112,11 +114,16 @@
 
     {# Concatenating the list of fastqs to reduce downstream processing #}
     cat {{ results_dir }}/*_list_fastq_files.txt > {{ results_dir }}/{{ tumor.name }}_list_of_fastqs.txt
-    find {{ results_dir }}/ -name '*_list_fastq_files.txt' \! -name '{{ tumor.name }}_list_of_fastqs.txt' -delete
+    find {{ results_dir }}/ -name '*_list_fastq_*.txt' \! -name '{{ tumor.name }}_list_of_fastqs.txt' -delete
+
+    tar -czf {{ results_dir }}/{{ tumor.name }}_fastqs.tar.gz {{ results_dir }}/*.fastq.gz
+
 
 - name: trinity_assembly_{{ tumor.name }}
   tags: [assembly,]
-  input: {{ results_dir }}/{{ tumor.name }}_list_of_fastqs.txt
+  input: 
+    - {{ results_dir }}/{{ tumor.name }}_list_of_fastqs.txt
+    - {{ results_dir }}/{{ tumor.name }}_fastqs.tar.gz
   output:
     - {{ results_dir }}/{{ tumor.name }}_Trinity_All_Clusters_sorted.bam
     - {{ results_dir }}/{{ tumor.name }}_ContigResults.txt
@@ -156,6 +163,9 @@
       rightfq=${fqr2arr[i]}
       chrRegion=$(echo ${leftfq#{{ results_dir }}/{{ tumor.name }}_} | cut -d'_' -f1-3)
       cluster=$(echo ${leftfq#{{ results_dir }}/{{ tumor.name }}_} | cut -d'_' -f4-6)
+      {# Pulling the needed fastqs out of the tar.gz #}
+      tar -xzf {{ results_dir }}/{{ tumor.name }}_fastqs.tar.gz ${leftfq}
+      tar -xzf {{ results_dir }}/{{ tumor.name }}_fastqs.tar.gz ${rightfq}
       Trinity \
         --seqType fq \
         --left $leftfq \
@@ -207,6 +217,7 @@
         samtools index {{ results_dir }}/{{ tumor.name }}_${chrRegion}_${cluster}/{{ tumor.name }}_${chrRegion}_${cluster}_ReadstoContigs.bam
 
         assemBam+=("{{ temp_dir }}/{{ tumor.name }}_${chrRegion}_${cluster}/trinity/{{ tumor.name }}_${chrRegion}_${cluster}_sorted.bam")
+        rm ${leftfq} ${rightfq}
       fi
       i=$(expr $i + 1)
     done
@@ -255,7 +266,7 @@
     touch {{ results_dir }}/{{ tumor.name }}_ContigResults.txt
     touch {{ results_dir }}/{{ tumor.name }}_FilteredContigResults.txt
     touch {{ results_dir }}/{{ tumor.name }}_Trinity_All_Clusters_sorted.bam
-    rm {{ results_dir }}/r1counts.txt || true
+
 
 {% endmacro %}
 

--- a/modules/tumor_only/mm_igtx_calling.jst
+++ b/modules/tumor_only/mm_igtx_calling.jst
@@ -179,6 +179,7 @@
       if [[ -v error ]]
       then
         assemErrors=$(expr $assemErrors + 1)
+        rm ${leftfq} ${rightfq}
         unset error
       else
         ${trin_path}/util/TrinityStats.pl {{ temp_dir }}/{{ tumor.name }}_${chrRegion}_${cluster}/trinity/Trinity.fasta

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -86,9 +86,9 @@ constants:
         ExpansionHunter: A sequence-graph based tool to analyze variation in short tandem repeat regions,
         Bioinformatics 2019
     fgbio:
-      module: fgbio/1.5.0
-      version: "1.5.0"
-      verbose: fgbio v1.5.0
+      module: fgbio/2.0.2
+      version: "2.0.2"
+      verbose: fgbio v2.0.2
       website: https://github.com/fulcrumgenomics/fgbio
     freebayes:
       module: freebayes/1.3.1-foss-2019a


### PR DESCRIPTION
Updates for UMI alignment workflow:
- Moved to fgbio 2.0.2 and associated best practice workflow

GaMMiT changes:
- Improved I/O traceability by tar.gz-ing the fastqs generated by DLE. Allows us to make sure we copy down the required fastqs for Trinity

I will need to resolve the fgbio stats collection, but this does not impact the results, mainly improves debugging. Leave branch open after merging.

